### PR TITLE
[✨ feat] Tab 컴포넌트 제작 (#13)

### DIFF
--- a/src/components/ui/Tab.tsx
+++ b/src/components/ui/Tab.tsx
@@ -1,0 +1,113 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '@/utils/cn';
+
+interface TabItem {
+  id: string;
+  label: string;
+  content?: ReactNode;
+}
+
+interface TabProps {
+  items: TabItem[];
+  activeTab: string;
+  onTabChange: (tabId: string) => void;
+  className?: string;
+  tabClassName?: string;
+  activeTabClassName?: string;
+  variant?: 'full' | 'fit';
+}
+
+const baseContainerStyles = 'border-foundation-divider relative flex border-b';
+const baseTabStyles =
+  'typo-subhead-03 relative cursor-pointer transition-colors';
+const variantStyles = {
+  full: {
+    padding: 'p-2.5',
+    layout: 'flex-1',
+    position: 'left-0 right-0',
+  },
+  fit: {
+    padding: 'px-5 py-2.5',
+    layout: 'shrink-0',
+    position: 'left-5 right-5',
+  },
+};
+const stateStyles = {
+  active: 'text-primary-btn',
+  inactive: 'text-foundation-disabled',
+};
+
+const Tab = ({
+  items,
+  activeTab,
+  onTabChange,
+  className,
+  tabClassName,
+  activeTabClassName,
+  variant = 'full',
+}: TabProps) => {
+  const activeItem = items.find(item => item.id === activeTab);
+
+  return (
+    <div className={className}>
+      <TabGroupHeader
+        items={items}
+        activeTab={activeTab}
+        onTabChange={onTabChange}
+        tabClassName={tabClassName}
+        activeTabClassName={activeTabClassName}
+        variant={variant}
+      />
+      {activeItem?.content && (
+        <div className="px-5 py-8">{activeItem.content}</div>
+      )}
+    </div>
+  );
+};
+
+const TabGroupHeader = ({
+  items,
+  activeTab,
+  onTabChange,
+  className,
+  tabClassName,
+  activeTabClassName,
+  variant = 'full',
+}: TabProps) => {
+  const variantConfig = variantStyles[variant];
+
+  return (
+    <div className={cn(baseContainerStyles, className)}>
+      {items.map(item => {
+        const isActive = item.id === activeTab;
+        return (
+          <button
+            key={item.id}
+            onClick={() => onTabChange(item.id)}
+            className={cn(
+              baseTabStyles,
+              variantConfig.padding,
+              variantConfig.layout,
+              isActive ? stateStyles.active : stateStyles.inactive,
+              tabClassName,
+              isActive && activeTabClassName,
+            )}
+          >
+            {item.label}
+            <div
+              className={cn(
+                'bg-primary-btn absolute bottom-0 h-[3px] transition-all duration-300',
+                variantConfig.position,
+                isActive ? 'scale-x-100 opacity-100' : 'scale-x-50 opacity-0',
+              )}
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export type { TabItem, TabProps };
+export { Tab, TabGroupHeader };

--- a/src/components/ui/Tab.tsx
+++ b/src/components/ui/Tab.tsx
@@ -15,6 +15,7 @@ interface TabProps {
   className?: string;
   tabClassName?: string;
   activeTabClassName?: string;
+  contentClassName?: string;
   variant?: 'full' | 'fit';
 }
 
@@ -45,6 +46,7 @@ const Tab = ({
   className,
   tabClassName,
   activeTabClassName,
+  contentClassName,
   variant = 'full',
 }: TabProps) => {
   const activeItem = items.find(item => item.id === activeTab);
@@ -60,7 +62,9 @@ const Tab = ({
         variant={variant}
       />
       {activeItem?.content && (
-        <div className="px-5 py-8">{activeItem.content}</div>
+        <div className={cn('px-5 py-8', contentClassName)}>
+          {activeItem.content}
+        </div>
       )}
     </div>
   );
@@ -83,6 +87,7 @@ const TabGroupHeader = ({
         const isActive = item.id === activeTab;
         return (
           <button
+            type="button"
             key={item.id}
             onClick={() => onTabChange(item.id)}
             className={cn(


### PR DESCRIPTION
## 🔗 Related Issue

- close #13 
- ref #issue_number

## ✨ What’s this PR?

<!-- 어떤 기능/수정인지 간단히 설명해주세요 -->
상단 탭을 표시하는 `Tab` 컴포넌트를 제작했어요.

## ✅ Done

- [x] `Tab`, `TabGroupHeader` 컴포넌트 제작

## 💬 Notes for Reviewer

<!-- 리뷰어가 확인했으면 하는 포인트, 의문점, 논의할 사항 등을 자유롭게 작성해주세요 -->
- `variant` 옵션은 탭의 하단 border 표시 방식을 구분해요.
- **`full`**: 탭들이 전체 너비를 균등 분할하며, 활성 탭의 하단 보더가 해당 탭의 전체 너비에 걸쳐 표시돼요.
  (ex. 피그마의 `기록하기`, `회고 둘러보기` - 각각 50% 너비를 차지하고 보더도 50% 너비로 표시)
- **`fit`**: 탭들이 텍스트 길이에 맞게 크기가 조절되며, 활성 탭의 하단 보더가 텍스트 길이에 맞춰 표시돼요.
  (ex. 피그마의 `면접 정보`, `질문과 답변`, `면접 후기`, `첨부` - 각 탭이 텍스트 길이만큼만 차지하고 보더도 텍스트에 맞게 표시)

**컴포넌트 구성**

- **`TabGroupHeader`**: 탭 헤더만 렌더링하는 컴포넌트 (내용 없이 탭 버튼들만 표시)
- **`Tab`**: 탭 헤더 + 선택된 탭에 해당하는 콘텐츠까지 모두 렌더링하는 완전한 탭 컴포넌트

```tsx
const [activeTab, setActiveTab] = useState('questions');

  const subTabItems: TabItem[] = [
    {
      id: 'info',
      label: '면접 정보',
      content: <div>면접 정보 콘텐츠</div>,
    },
    {
      id: 'questions',
      label: '질문과 답변',
      content: <div>질문과 답변 콘텐츠</div>,
    },
    {
      id: 'review',
      label: '면접 후기',
      content: <div>면접 후기 콘텐츠</div>,
    },
    {
      id: 'attachments',
      label: '첨부',
      content: <div>첨부 콘텐츠</div>,
    },
  ];

  return (
    <Tab
      items={subTabItems}
      activeTab={activeTab}
      onTabChange={setActiveTab}
      variant="fit"
    />
  );
```

사용하는 곳에서는 이렇게 item을 정의하고 사용하면 됩니다.

## 📷 Screenshot / Demo

https://github.com/user-attachments/assets/45b09e78-3bdc-4f8d-8c50-e7f241c13f52



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new tab component for switching between different content sections within the interface.
  * Added support for customizable tab layouts and animated underline indicators for active tabs.
  * Tabs can be controlled externally, allowing integration with other components and state management.
  * Styling and layout of tabs are configurable with different variants and class overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->