### PR TITLE
[✨ feat] Header 공통 컴포넌트 제작 (#27)

### DIFF
--- a/src/assets/icon/left_arrow_icon.svg
+++ b/src/assets/icon/left_arrow_icon.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 18L9 12L15 6" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -49,17 +49,14 @@ function Header({
         )}
         onClick={onRightClick}
       >
-        {rightContent && (
-          <>
-            {typeof rightContent === 'string' ? (
-              <span className="typo-body-02 text-foundation-strong">
-                {rightContent}
-              </span>
-            ) : (
-              rightContent
-            )}
-          </>
-        )}
+        {rightContent &&
+          (typeof rightContent === 'string' ? (
+            <span className="typo-body-02 text-foundation-strong">
+              {rightContent}
+            </span>
+          ) : (
+            rightContent
+          ))}
       </div>
     </header>
   );

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import LeftArrowIcon from '@/assets/icon/left_arrow_icon.svg';
+import { cn } from '@/utils/cn';
+
+interface Props {
+  title: string;
+  rightContent?: ReactNode | string;
+  onBackClick?: () => void;
+  onRightClick?: () => void;
+  showBackButton?: boolean;
+}
+
+function Header({
+  title,
+  rightContent,
+  onBackClick,
+  onRightClick,
+  showBackButton = true,
+}: Props) {
+  const handleBackClick = () => {
+    if (onBackClick) {
+      onBackClick();
+    } else {
+      window.history.back();
+    }
+  };
+
+  return (
+    <header className="border-foundation-divider relative border py-6">
+      {showBackButton && (
+        <LeftArrowIcon
+          className="absolute top-1/2 left-6 -translate-y-1/2 cursor-pointer"
+          aria-label="뒤로 가기"
+          onClick={handleBackClick}
+        />
+      )}
+
+      <div className={cn('text-center', !showBackButton && 'px-6')}>
+        <span className="typo-headline text-foundation-strong">{title}</span>
+      </div>
+
+      <div
+        className={cn(
+          'absolute top-1/2 right-6 flex -translate-y-1/2 items-center',
+          onRightClick && 'cursor-pointer',
+        )}
+        onClick={onRightClick}
+      >
+        {rightContent && (
+          <>
+            {typeof rightContent === 'string' ? (
+              <span className="typo-body-02 text-foundation-strong">
+                {rightContent}
+              </span>
+            ) : (
+              rightContent
+            )}
+          </>
+        )}
+      </div>
+    </header>
+  );
+}
+
+export { Header };


### PR DESCRIPTION
## 🔗 Related Issue

- close #27 
- ref #27

---

## ✨ What’s this PR?

<!-- 어떤 기능/수정인지 간단히 설명해주세요 -->
풀스크린이나, 페이지 헤더에서 사용할 공통 컴포넌트를 제작했어요.

---

## ✅ Done

- [x] 공통 `Header` 컴포넌트 제작

---

## 💬 Notes for Reviewer

<!-- 리뷰어가 확인했으면 하는 포인트, 의문점, 논의할 사항 등을 자유롭게 작성해주세요 -->
- 일반 페이지에서는 `showBackButton={false}`로 사용하면 되고, 풀스크린에서는 `title` 적절히 사용하고 오른쪽에 콘텐츠가 있다면 `rightContent`를 사용할 수 있어요.

---

## 📷 Screenshot / Demo

<img width="471" height="237" alt="image" src="https://github.com/user-attachments/assets/0165e43b-50e5-47e9-98ab-1dd09ded886a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a reusable header bar component for pages.
  - Optional back button (enabled by default) with automatic fallback to browser back navigation.
  - Centered title display with optional right-side action/content (text or custom element).
  - Right-side area can be made clickable and shows interactive styling when clickable.
  - Accessibility improvement: back button includes an aria-label for screen readers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->