### PR TITLE
[✨ feat] 마이페이지 퍼블리싱 (#41)

### DIFF
--- a/src/app/(fullscreen)/my-page/comments/page.tsx
+++ b/src/app/(fullscreen)/my-page/comments/page.tsx
@@ -1,0 +1,9 @@
+import { Header } from '@/components/ui/Header';
+
+export default function MyCommentsPage() {
+  return (
+    <>
+      <Header title="내가 댓글 남긴 글" />
+    </>
+  );
+}

--- a/src/app/(fullscreen)/my-page/comments/page.tsx
+++ b/src/app/(fullscreen)/my-page/comments/page.tsx
@@ -1,9 +1,13 @@
 import { Header } from '@/components/ui/Header';
 
+import MemoirList from '../components/MemoirList';
+import { mockMemoirs } from '../mocks/memoir';
+
 export default function MyCommentsPage() {
   return (
-    <>
+    <main className="flex h-screen flex-col">
       <Header title="내가 댓글 남긴 글" />
-    </>
+      <MemoirList memoirs={mockMemoirs} emptyText="작성한 댓글이 없어요." />
+    </main>
   );
 }

--- a/src/app/(fullscreen)/my-page/components/MemoirItem.tsx
+++ b/src/app/(fullscreen)/my-page/components/MemoirItem.tsx
@@ -1,0 +1,45 @@
+import { Badge } from '@/components/ui/Badge';
+import { MEMOIR_TYPES } from '@/constants/code';
+import { MEMOIR_TYPE_LABELS, POSITION_LABELS } from '@/constants/labels';
+import type { Memoir } from '@/types/memoirTypes';
+
+interface Props {
+  memoir: Memoir;
+  hideBadge?: boolean;
+}
+
+export default function MemoirItem({ memoir, hideBadge = false }: Props) {
+  const badgeText =
+    MEMOIR_TYPE_LABELS[memoir.type as keyof typeof MEMOIR_TYPE_LABELS];
+  const badgeTextColor =
+    memoir.type === MEMOIR_TYPES.QUICK
+      ? 'text-secondary-btn'
+      : 'text-primary-btn';
+
+  return (
+    <>
+      <article className="bg-foundation-box cursor-pointer rounded-lg p-3">
+        <div className="flex items-center gap-3">
+          {!hideBadge && (
+            <Badge className={badgeTextColor} shape="minimal" size="xsmall">
+              {badgeText}
+            </Badge>
+          )}
+          <div className="flex items-center gap-[6px]">
+            <h3 className="typo-subhead-long-03 text-foundation-primary">
+              {memoir.companyName}
+            </h3>
+            <span className="typo-subhead-02 text-foundation-disabled">|</span>
+            <p className="typo-subhead-long-03 text-foundation-primary">
+              {POSITION_LABELS[memoir.position as keyof typeof POSITION_LABELS]}
+            </p>
+          </div>
+        </div>
+
+        <p className="typo-caption text-foundation-disabled mt-1">
+          작성일 : {memoir.createdAt.replaceAll('-', '.')}
+        </p>
+      </article>
+    </>
+  );
+}

--- a/src/app/(fullscreen)/my-page/components/MemoirList.tsx
+++ b/src/app/(fullscreen)/my-page/components/MemoirList.tsx
@@ -1,0 +1,26 @@
+import type { Memoir } from '@/types/memoirTypes';
+
+import MemoirItem from './MemoirItem';
+import { EmptyState } from '@/components/ui/Empty';
+
+interface Props {
+  memoirs: Memoir[];
+  hideBadge?: boolean;
+  emptyText: string;
+}
+
+export default function MemoirList({ memoirs, hideBadge, emptyText }: Props) {
+  return (
+    <>
+      <div className="mt-8 flex flex-1 flex-col gap-3 px-5">
+        {memoirs.length > 0 ? (
+          memoirs.map(memoir => (
+            <MemoirItem key={memoir.id} memoir={memoir} hideBadge={hideBadge} />
+          ))
+        ) : (
+          <EmptyState text={emptyText} />
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/app/(fullscreen)/my-page/components/MyMemoirsView.tsx
+++ b/src/app/(fullscreen)/my-page/components/MyMemoirsView.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { Chip } from '@/components/ui/Chip';
+import { MEMOIR_TYPES } from '@/constants/code';
+import type { MemoirType } from '@/types/memoirTypes';
+
+import { mockMemoirs } from '../mocks/memoir';
+
+import MemoirList from './MemoirList';
+
+const filterChips: { label: string; value: 'all' | MemoirType }[] = [
+  { label: '전체', value: 'all' },
+  { label: '퀵회고', value: MEMOIR_TYPES.QUICK },
+  { label: '일반회고', value: MEMOIR_TYPES.GENERAL },
+];
+
+export default function MyMemoirsView() {
+  const [selectedFilter, setSelectedFilter] = useState<'all' | MemoirType>(
+    'all',
+  );
+
+  const allMemoirs = mockMemoirs;
+
+  const filteredMemoirs = useMemo(() => {
+    if (selectedFilter === 'all') {
+      return allMemoirs;
+    }
+    return allMemoirs.filter(memoir => memoir.type === selectedFilter);
+  }, [allMemoirs, selectedFilter]);
+
+  return (
+    <div className="flex flex-1 flex-col">
+      {allMemoirs.length > 0 && (
+        <div className="flex items-center gap-2 px-5 py-6">
+          {filterChips.map(chip => (
+            <Chip
+              key={chip.value}
+              text={chip.label}
+              isSelected={selectedFilter === chip.value}
+              onClick={() => setSelectedFilter(chip.value)}
+            />
+          ))}
+        </div>
+      )}
+      <MemoirList memoirs={filteredMemoirs} emptyText="작성된 회고가 없어요." />
+    </div>
+  );
+}

--- a/src/app/(fullscreen)/my-page/likes/page.tsx
+++ b/src/app/(fullscreen)/my-page/likes/page.tsx
@@ -1,0 +1,9 @@
+import { Header } from '@/components/ui/Header';
+
+export default function MyLikesPage() {
+  return (
+    <>
+      <Header title="내가 좋아요한 글" />
+    </>
+  );
+}

--- a/src/app/(fullscreen)/my-page/likes/page.tsx
+++ b/src/app/(fullscreen)/my-page/likes/page.tsx
@@ -1,9 +1,13 @@
 import { Header } from '@/components/ui/Header';
 
+import MemoirList from '../components/MemoirList';
+import { mockMemoirs } from '../mocks/memoir';
+
 export default function MyLikesPage() {
   return (
-    <>
+    <main className="flex h-screen flex-col">
       <Header title="내가 좋아요한 글" />
-    </>
+      <MemoirList memoirs={mockMemoirs} emptyText="좋아요한 글이 없어요." />
+    </main>
   );
 }

--- a/src/app/(fullscreen)/my-page/memoirs/page.tsx
+++ b/src/app/(fullscreen)/my-page/memoirs/page.tsx
@@ -1,9 +1,12 @@
 import { Header } from '@/components/ui/Header';
 
+import MyMemoirsView from '../components/MyMemoirsView';
+
 export default function MyMemoirsPage() {
   return (
-    <>
+    <main className="flex h-screen flex-col">
       <Header title="나의 회고 리스트" />
-    </>
+      <MyMemoirsView />
+    </main>
   );
 }

--- a/src/app/(fullscreen)/my-page/memoirs/page.tsx
+++ b/src/app/(fullscreen)/my-page/memoirs/page.tsx
@@ -1,0 +1,9 @@
+import { Header } from '@/components/ui/Header';
+
+export default function MyMemoirsPage() {
+  return (
+    <>
+      <Header title="나의 회고 리스트" />
+    </>
+  );
+}

--- a/src/app/(fullscreen)/my-page/mocks/memoir.ts
+++ b/src/app/(fullscreen)/my-page/mocks/memoir.ts
@@ -1,0 +1,50 @@
+import { INTERVIEW_STATUS, MEMOIR_TYPES, POSITION } from '@/constants/code';
+import { Memoir } from '@/types/memoirTypes';
+
+export const mockMemoirs: Memoir[] = [
+  {
+    id: 1,
+    type: MEMOIR_TYPES.QUICK,
+    interviewStatus: INTERVIEW_STATUS.PENDING,
+    companyName: '네이버',
+    position: POSITION.PLANNING_STRATEGY,
+    createdAt: '2025-08-08',
+    firstQuestion: '네이버 서비스 중 개선하고 싶은 점이 있다면?',
+  },
+  {
+    id: 2,
+    type: MEMOIR_TYPES.QUICK,
+    interviewStatus: INTERVIEW_STATUS.PENDING,
+    companyName: '배달의 민족',
+    position: POSITION.DESIGN,
+    createdAt: '2025-08-08',
+    firstQuestion: '배달의 민족 앱의 UX에서 가장 중요하다고 생각하는 것은?',
+  },
+  {
+    id: 3,
+    type: MEMOIR_TYPES.QUICK,
+    interviewStatus: INTERVIEW_STATUS.PENDING,
+    companyName: '(주)실천',
+    position: POSITION.DESIGN,
+    createdAt: '2025-08-08',
+    firstQuestion: '자신이 사용해본 서비스 중 가장 UI가 뛰어났던 것은?',
+  },
+  {
+    id: 5,
+    type: MEMOIR_TYPES.QUICK,
+    interviewStatus: INTERVIEW_STATUS.PENDING,
+    companyName: '당근',
+    position: POSITION.DEVELOPMENT_DATA,
+    createdAt: '2025-08-16',
+    firstQuestion: '가상화가 무엇인가요?',
+  },
+  {
+    id: 6,
+    type: MEMOIR_TYPES.GENERAL,
+    interviewStatus: INTERVIEW_STATUS.PASS,
+    companyName: '(주)캐럿글로벌',
+    position: POSITION.PLANNING_STRATEGY,
+    createdAt: '2025-08-08',
+    firstQuestion: '데이터를 기반으로 UX를 개선해본 경험이 있나요?',
+  },
+];

--- a/src/app/(fullscreen)/my-page/profile-modify/components/ProfileModifyView.tsx
+++ b/src/app/(fullscreen)/my-page/profile-modify/components/ProfileModifyView.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState, type ChangeEvent } from 'react';
+
+import { Button } from '@/components/ui/Button';
+import { Header } from '@/components/ui/Header';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import PlusIcon from '@/assets/icon/plus_icon2.svg';
+
+interface Props {
+  initialNickname: string;
+}
+
+export default function ProfileModifyView({ initialNickname }: Props) {
+  const [nickname, setNickname] = useState(initialNickname);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+
+  const isNicknameValid = nickname.trim().length > 0 && nickname.length <= 8;
+  const hasContentChanged = nickname !== initialNickname || !!imageFile;
+  const isSaveButtonDisabled = !isNicknameValid || !hasContentChanged;
+
+  const handleSave = () => {
+    history.back();
+  };
+
+  const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault();
+
+    const file = e.target.files?.[0];
+    if (file) {
+      setImageFile(file);
+
+      const previewUrl = URL.createObjectURL(file);
+      setImagePreview(previewUrl);
+    }
+  };
+
+  return (
+    <div className="flex h-screen flex-col">
+      <Header
+        title="프로필 편집"
+        rightContent="완료"
+        onRightClick={handleSave}
+      />
+
+      <main className="flex-1 px-5">
+        <label htmlFor="profile-image-upload" className="cursor-pointer">
+          <figure className="mt-7 flex justify-center">
+            <div className="relative h-[100px] w-[100px]">
+              <div
+                className="h-full w-full rounded-full bg-gray-200 bg-cover bg-center"
+                style={{
+                  backgroundImage: imagePreview
+                    ? `url(${imagePreview})`
+                    : 'none',
+                }}
+              />
+
+              <div className="absolute right-0 bottom-0 flex h-6 w-6 items-center justify-center rounded-full bg-white p-[6px]">
+                <PlusIcon />
+              </div>
+            </div>
+          </figure>
+        </label>
+
+        <input
+          id="profile-image-upload"
+          type="file"
+          accept="image/*"
+          onChange={handleImageChange}
+          className="hidden"
+        />
+
+        <div className="mt-6">
+          <Label label="닉네임" />
+          <Input
+            placeholder="내용 입력"
+            className="mt-2"
+            value={nickname}
+            onChange={e => setNickname(e.target.value)}
+            maxLength={8}
+          />
+          <span className="text-foundation-disabled typo-body-01 mt-1">
+            최대 8글자 이내로 입력해주세요.
+          </span>
+        </div>
+      </main>
+
+      <footer className="px-5 pt-4 pb-6">
+        <Button
+          size="large"
+          disabled={isSaveButtonDisabled}
+          onClick={handleSave}
+        >
+          저장
+        </Button>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/(fullscreen)/my-page/profile-modify/page.tsx
+++ b/src/app/(fullscreen)/my-page/profile-modify/page.tsx
@@ -1,0 +1,13 @@
+import ProfileModifyView from './components/ProfileModifyView';
+
+async function getUserProfile() {
+  return {
+    nickname: 'SEED',
+  };
+}
+
+export default async function ProfileModifyPage() {
+  const user = await getUserProfile();
+
+  return <ProfileModifyView initialNickname={user.nickname} />;
+}

--- a/src/app/(fullscreen)/my-page/scrap/page.tsx
+++ b/src/app/(fullscreen)/my-page/scrap/page.tsx
@@ -1,9 +1,13 @@
 import { Header } from '@/components/ui/Header';
 
+import MemoirList from '../components/MemoirList';
+import { mockMemoirs } from '../mocks/memoir';
+
 export default function MyScrapPage() {
   return (
-    <>
+    <main className="flex h-screen flex-col">
       <Header title="내가 스크랩한 글" />
-    </>
+      <MemoirList memoirs={mockMemoirs} emptyText="스크랩한 글이 없어요." />
+    </main>
   );
 }

--- a/src/app/(fullscreen)/my-page/scrap/page.tsx
+++ b/src/app/(fullscreen)/my-page/scrap/page.tsx
@@ -1,0 +1,9 @@
+import { Header } from '@/components/ui/Header';
+
+export default function MyScrapPage() {
+  return (
+    <>
+      <Header title="내가 스크랩한 글" />
+    </>
+  );
+}

--- a/src/app/(fullscreen)/my-page/temp-saved/page.tsx
+++ b/src/app/(fullscreen)/my-page/temp-saved/page.tsx
@@ -1,9 +1,17 @@
 import { Header } from '@/components/ui/Header';
 
+import MemoirList from '../components/MemoirList';
+import { mockMemoirs } from '../mocks/memoir';
+
 export default function TempSavedPage() {
   return (
-    <>
+    <main className="flex h-screen flex-col">
       <Header title="임시 저장한 글" />
-    </>
+      <MemoirList
+        memoirs={mockMemoirs}
+        hideBadge={true}
+        emptyText="임시 저장한 글이 없어요."
+      />
+    </main>
   );
 }

--- a/src/app/(fullscreen)/my-page/temp-saved/page.tsx
+++ b/src/app/(fullscreen)/my-page/temp-saved/page.tsx
@@ -1,0 +1,9 @@
+import { Header } from '@/components/ui/Header';
+
+export default function TempSavedPage() {
+  return (
+    <>
+      <Header title="임시 저장한 글" />
+    </>
+  );
+}

--- a/src/app/(root)/my-page/page.tsx
+++ b/src/app/(root)/my-page/page.tsx
@@ -1,7 +1,84 @@
+import Link from 'next/link';
+
+import { Badge } from '@/components/ui/Badge';
+import { Header } from '@/components/ui/Header';
+import { PATH } from '@/constants/path';
+import RightArrow from '@/assets/icon/right_arrow_icon.svg';
+
+const MY_PAGE_METADATA = [
+  { href: PATH.MY_PAGE.MEMOIRS.path, label: PATH.MY_PAGE.MEMOIRS.label },
+  { href: PATH.MY_PAGE.TEMP_SAVED.path, label: PATH.MY_PAGE.TEMP_SAVED.label },
+  { href: PATH.MY_PAGE.LIKE.path, label: PATH.MY_PAGE.LIKE.label },
+  { href: PATH.MY_PAGE.COMMENTS.path, label: PATH.MY_PAGE.COMMENTS.label },
+  { href: PATH.MY_PAGE.SCRAP.path, label: PATH.MY_PAGE.SCRAP.label },
+];
+const ETC = ['로그아웃', '탈퇴하기'];
+
 export default function MyPage() {
   return (
     <>
-      <h1>My Page</h1>
+      <Header title="마이페이지" showBackButton={false} />
+      <main className="px-5 pt-7">
+        <div className="flex flex-col gap-4">
+          <section className="bg-foundation-box rounded-xl p-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-4">
+                <div className="bg-foundation-secondary h-12 w-12 rounded-full" />
+                <span className="typo-subhead-03 text-white">SEED</span>
+              </div>
+              <Link href={PATH.MY_PAGE.PROFILE_MODIFY.path}>
+                <Badge shape="round">{PATH.MY_PAGE.PROFILE_MODIFY.label}</Badge>
+              </Link>
+            </div>
+          </section>
+
+          <MenuSection title="나의 활동" items={MY_PAGE_METADATA} />
+          <MenuSection title="기타" items={ETC} />
+        </div>
+      </main>
     </>
+  );
+}
+
+function MenuSection({
+  title,
+  items = [],
+}: {
+  title: string;
+  items?: { href: string; label: string }[] | string[];
+}) {
+  return (
+    <section className="bg-foundation-box rounded-xl p-4">
+      <h3 className="text-foundation-strong typo-subhead-03 mb-2">{title}</h3>
+      <ul className="flex flex-col">
+        {Array.isArray(items)
+          ? items.map(item =>
+              typeof item === 'string' ? (
+                <li
+                  key={item}
+                  className="flex cursor-pointer items-center justify-between py-2"
+                >
+                  <span className="text-foundation-primary typo-body-02">
+                    {item}
+                  </span>
+                  <RightArrow />
+                </li>
+              ) : (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    className="flex cursor-pointer items-center justify-between py-2"
+                  >
+                    <span className="text-foundation-primary typo-body-02">
+                      {item.label}
+                    </span>
+                    <RightArrow />
+                  </Link>
+                </li>
+              ),
+            )
+          : null}
+      </ul>
+    </section>
   );
 }

--- a/src/assets/icon/plus_icon2.svg
+++ b/src/assets/icon/plus_icon2.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.9397 1.0603V12.9397M1 7H12.8794" stroke="black" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { cn } from '@/utils/cn';
+
+interface Props {
+  text: string;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+const baseStyles = 'rounded-full cursor-pointer px-4 py-1 typo-subhead-02';
+
+const variantStyle = {
+  default: 'bg-foundation-box border border-foundation-secondary',
+  filled: 'bg-foundation-strong border border-foundation-primary',
+};
+
+const textStyle = {
+  default: 'text-foundation-secondary',
+  filled: 'text-foundation-box',
+};
+
+function Chip({ text, isSelected, onClick }: Props) {
+  const variant = isSelected ? 'filled' : 'default';
+  const variantClasses = variantStyle[variant];
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(baseStyles, variantClasses)}
+    >
+      <span className={textStyle[variant]}>{text}</span>
+    </button>
+  );
+}
+
+export { Chip };

--- a/src/components/ui/Empty.tsx
+++ b/src/components/ui/Empty.tsx
@@ -1,0 +1,24 @@
+interface Props {
+  text: string;
+}
+
+function EmptyState({ text }: Props) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-6">
+      <ul className="flex items-center justify-center gap-2">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <li
+            className="bg-foundation-secondary h-2 w-2 rounded-full"
+            key={index}
+          />
+        ))}
+      </ul>
+
+      <span className="typo-headline text-foundation-secondary text-center">
+        {text}
+      </span>
+    </div>
+  );
+}
+
+export { EmptyState };

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -22,4 +22,13 @@ export const PATH = {
     QUICK: { path: '/home/memoir/quick', label: '퀵회고' },
     GENERAL: { path: '/home/memoir/general', label: '일반회고' },
   },
+
+  MY_PAGE: {
+    PROFILE_MODIFY: { path: '/my-page/profile-modify', label: '프로필 수정' },
+    MEMOIRS: { path: '/my-page/memoirs', label: '나의 회고' },
+    TEMP_SAVED: { path: '/my-page/temp-saved', label: '임시 저장한 글' },
+    LIKE: { path: '/my-page/likes', label: '내가 좋아요한 글' },
+    COMMENTS: { path: '/my-page/comments', label: '내가 댓글 남긴 글' },
+    SCRAP: { path: '/my-page/scrap', label: '내가 스크랩한 글' },
+  },
 } as const;

--- a/src/types/memoirTypes.ts
+++ b/src/types/memoirTypes.ts
@@ -78,11 +78,10 @@ export interface UpdateQuickMemoirsRequest {
 
 export interface Memoir {
   id: number;
-  type: MemoirType;
-  interviewStatus: InterviewStatus;
-  interviewMethod: InterviewMethod;
+  type: MemoirType | string;
+  interviewStatus: InterviewStatus | string;
   companyName: string;
-  position: Position;
+  position: Position | string;
   createdAt: string;
   firstQuestion: string;
 }


### PR DESCRIPTION
## 🔗 Related Issue

- close #41 
- ref #41

---

## ✨ What’s this PR?

<!-- 어떤 기능/수정인지 간단히 설명해주세요 -->
마이페이지 퍼블리싱 작업을 진행했어요.

---

## ✅ Done

- [x] `Chip` 공통 ui 컴포넌트 제작
- [x] `Empty` 공통 ui 컴포넌트 제작 (아이템이 비어있을 경우 사용)
- [x] 회고 리스트, 아이템 컴포넌트 제작 및 목데이터 제작
- [x] 마이페이지, 프로필 편집 페이지 퍼블리싱 

---

## 💬 Notes for Reviewer

<!-- 리뷰어가 확인했으면 하는 포인트, 의문점, 논의할 사항 등을 자유롭게 작성해주세요 -->
- 논의할 사항 등을 자유롭게 작성해주세요.

---

## 📷 Screenshot / Demo
![pc](https://example.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “My Page” sections: My Memoirs (with filters for 전체/퀵회고/일반회고), Likes, Comments, Scraps, and Temp Saved, each with empty states.
  - Introduced Profile Edit: update nickname (max 8 chars) and preview profile image before saving.
  - Improved memoir listing with clearer items and optional badges.
  - Added selectable chips and a friendly empty-state UI.

- Refactor
  - Revamped “My Page” layout with a header and structured menus for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->