### PR TITLE
[✨ feat] 일정 조회에서 정렬 드롭다운 추가 (#47)

### DIFF
--- a/src/app/(root)/schedule/components/ScheduleView.tsx
+++ b/src/app/(root)/schedule/components/ScheduleView.tsx
@@ -5,12 +5,14 @@ import Link from 'next/link';
 
 import { Chip } from '@/components/ui/Chip';
 import { PATH } from '@/constants/path';
+import { SortDropdown } from '@/components/ui/SortDropdown';
 import PlusIcon from '@/assets/icon/plus_icon3.svg';
 
 import ScheduleList from './ScheduleList';
 import { mockSchedules } from '../mocks/mockSchedule';
 
 type ScheduleFilter = 'all' | 'upcoming' | 'past';
+type SortType = 'registration' | 'imminent';
 
 const filterChips: { label: string; value: ScheduleFilter }[] = [
   { label: '전체', value: 'all' },
@@ -18,8 +20,15 @@ const filterChips: { label: string; value: ScheduleFilter }[] = [
   { label: '완료된 면접', value: 'past' },
 ];
 
+const sortOptions: { label: string; value: SortType }[] = [
+  { label: '면접 임박순', value: 'imminent' },
+  { label: '등록순', value: 'registration' },
+];
+
 export default function ScheduleView() {
   const [selectedFilter, setSelectedFilter] = useState<ScheduleFilter>('all');
+  const [selectedSort, setSelectedSort] = useState<SortType>('imminent');
+  const [isSortPopoverOpen, setIsSortPopoverOpen] = useState(false);
 
   const allSchedules = mockSchedules;
 
@@ -45,35 +54,55 @@ export default function ScheduleView() {
     }
 
     return schedules.sort((a, b) => {
-      const isAUpcoming = a.remainDate !== undefined;
-      const isBUpcoming = b.remainDate !== undefined;
-
-      if (isAUpcoming && !isBUpcoming) return -1;
-      if (!isAUpcoming && isBUpcoming) return 1;
-
-      if (isAUpcoming && isBUpcoming) {
-        return a.remainDate! - b.remainDate!;
+      if (selectedSort === 'imminent') {
+        const isAUpcoming = a.remainDate !== undefined;
+        const isBUpcoming = b.remainDate !== undefined;
+        if (isAUpcoming && !isBUpcoming) return -1;
+        if (!isAUpcoming && isBUpcoming) return 1;
+        if (isAUpcoming && isBUpcoming) {
+          return a.remainDate! - b.remainDate!;
+        }
+        return (
+          new Date(b.interviewDate).getTime() -
+          new Date(a.interviewDate).getTime()
+        );
       }
 
-      return (
-        new Date(b.interviewDate).getTime() -
-        new Date(a.interviewDate).getTime()
-      );
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
     });
-  }, [selectedFilter, allSchedules]);
+  }, [selectedFilter, selectedSort, allSchedules]);
+
+  const handleOverlayClick = () => {
+    setIsSortPopoverOpen(false);
+  };
 
   return (
     <div className="relative flex flex-1 flex-col">
+      {isSortPopoverOpen && (
+        <div
+          onClick={handleOverlayClick}
+          className="fixed top-0 right-0 bottom-0 left-0 z-10 bg-black/50 transition-opacity duration-200"
+        />
+      )}
       {allSchedules.length > 0 && (
-        <div className="flex items-center gap-2 px-5 py-8">
-          {filterChips.map(chip => (
-            <Chip
-              key={chip.value}
-              text={chip.label}
-              isSelected={selectedFilter === chip.value}
-              onClick={() => setSelectedFilter(chip.value)}
-            />
-          ))}
+        <div className="flex items-center gap-3 px-5 py-8">
+          <SortDropdown
+            isOpen={isSortPopoverOpen}
+            setIsOpen={setIsSortPopoverOpen}
+            options={sortOptions}
+            value={selectedSort}
+            onValueChange={setSelectedSort}
+          />
+          <div className="flex items-center gap-2">
+            {filterChips.map(chip => (
+              <Chip
+                key={chip.value}
+                text={chip.label}
+                isSelected={selectedFilter === chip.value}
+                onClick={() => setSelectedFilter(chip.value)}
+              />
+            ))}
+          </div>
         </div>
       )}
       <ScheduleList

--- a/src/assets/icon/dropdown_icon2.svg
+++ b/src/assets/icon/dropdown_icon2.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="8" viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1.5L6 6.5L11 1.5" stroke="#CCCCCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/ui/SortDropdown.tsx
+++ b/src/components/ui/SortDropdown.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+
+import { cn } from '@/utils/cn';
+import DropdownIcon from '@/assets/icon/dropdown_icon2.svg';
+
+type SortOption<T extends string> = {
+  label: string;
+  value: T;
+};
+
+interface Props<T extends string> {
+  options: readonly SortOption<T>[];
+  value: T;
+  onValueChange: (value: T) => void;
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+}
+
+const useOnClickOutside = (
+  ref: React.RefObject<HTMLDivElement | null>,
+  handler: () => void,
+) => {
+  useEffect(() => {
+    const listner = (e: MouseEvent | TouchEvent) => {
+      if (!ref.current || ref.current.contains(e.target as Node)) {
+        return;
+      }
+      handler();
+    };
+    document.addEventListener('mousedown', listner);
+    document.addEventListener('touchstart', listner);
+
+    return () => {
+      document.removeEventListener('mousedown', listner);
+      document.removeEventListener('touchstart', listner);
+    };
+  }, [ref, handler]);
+};
+
+export function SortDropdown<T extends string>({
+  options,
+  value,
+  onValueChange,
+  isOpen,
+  setIsOpen,
+}: Props<T>) {
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useOnClickOutside(dropdownRef, () => setIsOpen(false));
+
+  const selectedLabel =
+    options.find(option => option.value === value)?.label || '';
+
+  const handleOptionClick = (optionValue: T) => {
+    onValueChange(optionValue);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative z-20" ref={dropdownRef}>
+      <div
+        className="flex cursor-pointer items-center gap-1"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <span className="text-foundation-primary typo-subhead-02">
+          {selectedLabel}
+        </span>
+        <DropdownIcon />
+      </div>
+
+      <div
+        className={cn(
+          'bg-foundation-box absolute top-full left-0 z-10 mt-3 w-max rounded-xl px-4 py-3',
+          'transition-all duration-200 ease-in-out',
+          isOpen
+            ? 'visible scale-100 opacity-100'
+            : 'invisible scale-95 opacity-0',
+        )}
+      >
+        {options.map((option, index) => (
+          <div key={option.value}>
+            <div
+              onClick={() => handleOptionClick(option.value)}
+              className={cn(
+                'typo-subhead-02 cursor-pointer',
+                value === option.value
+                  ? 'text-foundation-strong'
+                  : 'text-foundation-disabled',
+              )}
+            >
+              {option.label}
+            </div>
+            {index < options.length - 1 && (
+              <div className="bg-foundation-divider my-2 h-px" />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 🔗 Related Issue

- close #47
- ref #47

---

## ✨ What’s this PR?

<!-- 어떤 기능/수정인지 간단히 설명해주세요 -->
일정 조회에서 정렬 드롭다운을 추가했어요.

---

## ✅ Done

- [x] `SortDropdown` 공통 ui 컴포넌트 제작
- [x] 일정 조회 페이지에 `SortDropdown` 컴포넌트 적용

---

## 💬 Notes for Reviewer

<!-- 리뷰어가 확인했으면 하는 포인트, 의문점, 논의할 사항 등을 자유롭게 작성해주세요 -->
- 논의할 사항 등을 자유롭게 작성해주세요.

---

## 📷 Screenshot / Demo
<img width="458" height="643" alt="image" src="https://github.com/user-attachments/assets/440a1d9a-3d4a-4691-91bb-ca40e5dfecfe" />

<img width="455" height="748" alt="image" src="https://github.com/user-attachments/assets/dfce345d-84a9-4caa-abcc-719baf753019" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Sort dropdown in Schedule view to choose ordering: by imminence (upcoming first) or by registration date (newest first).
  - Sorting now applies together with existing filters (upcoming/past/all) to the displayed list.
  - Click-outside support closes the sort popover for easier navigation.

- Style
  - Updated Schedule header to combine filter chips with the new Sort control.
  - Improved dropdown visuals and transitions for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->