### PR TITLE
[✨ feat] 질문 카테고리에 대한 페이지 제작 (#51)

### DIFF
--- a/src/app/(fullscreen)/home/questions/company/page.tsx
+++ b/src/app/(fullscreen)/home/questions/company/page.tsx
@@ -1,6 +1,10 @@
 import { Metadata } from 'next';
 
 import { Header } from '@/components/ui/Header';
+import SearchIcon from '@/assets/icon/search_icon.svg';
+
+import QuestionList from '../components/QuestionList';
+import { mockQuestionCategory } from '../mocks/mockQuestionCategory';
 
 export const metadata: Metadata = {
   title: '회사질문',
@@ -10,7 +14,10 @@ export const metadata: Metadata = {
 export default function CompanyQuestionsPage() {
   return (
     <>
-      <Header title="회사질문" />
+      <Header title="회사질문" rightContent={<SearchIcon />} />
+      <section className="px-5">
+        <QuestionList questions={mockQuestionCategory} />
+      </section>
     </>
   );
 }

--- a/src/app/(fullscreen)/home/questions/company/page.tsx
+++ b/src/app/(fullscreen)/home/questions/company/page.tsx
@@ -1,9 +1,6 @@
 import { Metadata } from 'next';
 
-import { Header } from '@/components/ui/Header';
-import SearchIcon from '@/assets/icon/search_icon.svg';
-
-import QuestionList from '../components/QuestionList';
+import QuestionContainer from '../components/QuestionContainer';
 import { mockQuestionCategory } from '../mocks/mockQuestionCategory';
 
 export const metadata: Metadata = {
@@ -14,10 +11,10 @@ export const metadata: Metadata = {
 export default function CompanyQuestionsPage() {
   return (
     <>
-      <Header title="회사질문" rightContent={<SearchIcon />} />
-      <section className="px-5">
-        <QuestionList questions={mockQuestionCategory} />
-      </section>
+      <QuestionContainer
+        initialQuestions={mockQuestionCategory}
+        title="회사질문"
+      />
     </>
   );
 }

--- a/src/app/(fullscreen)/home/questions/components/QuestionContainer.tsx
+++ b/src/app/(fullscreen)/home/questions/components/QuestionContainer.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+
+import { Header } from '@/components/ui/Header';
+import { Input } from '@/components/ui/Input';
+import SearchIcon from '@/assets/icon/search_icon.svg';
+import type { Question } from '@/types/memoirTypes';
+
+import QuestionList from './QuestionList';
+import RecentSearch from './RecentSearch';
+
+interface Props {
+  initialQuestions: Question[];
+  title: string;
+}
+
+export default function QuestionContainer({ initialQuestions, title }: Props) {
+  const [isSearching, setIsSearching] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const [submittedTerm, setSubmittedTerm] = useState('');
+
+  const filteredQuestions = useMemo(() => {
+    if (!submittedTerm.trim()) {
+      return initialQuestions;
+    }
+    return initialQuestions.filter(
+      question =>
+        question.content.toLowerCase().includes(submittedTerm.toLowerCase()) ||
+        (question.answer &&
+          question.answer.toLowerCase().includes(submittedTerm.toLowerCase())),
+    );
+  }, [submittedTerm, initialQuestions]);
+
+  const handleStartSearch = () => {
+    setIsSearching(true);
+  };
+
+  const handleCancelSearch = () => {
+    setIsSearching(false);
+    setInputValue('');
+    setSubmittedTerm('');
+  };
+
+  const handleSubmitSearch = () => {
+    setSubmittedTerm(inputValue);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSubmitSearch();
+    }
+  };
+
+  return (
+    <>
+      <Header
+        onBackClick={isSearching ? handleCancelSearch : undefined}
+        title={
+          isSearching ? (
+            <Input
+              type="text"
+              value={inputValue}
+              onChange={e => setInputValue(e.target.value)}
+              placeholder="검색어를 입력하세요."
+              onClear={() => setInputValue('')}
+              onKeyDown={handleKeyDown}
+              autoFocus
+            />
+          ) : (
+            title
+          )
+        }
+        rightContent={<SearchIcon />}
+        onRightClick={isSearching ? handleSubmitSearch : handleStartSearch}
+      />
+
+      <section className="px-5">
+        {isSearching ? (
+          submittedTerm ? (
+            <QuestionList questions={filteredQuestions} />
+          ) : (
+            <RecentSearch />
+          )
+        ) : (
+          <QuestionList questions={initialQuestions} />
+        )}
+      </section>
+    </>
+  );
+}

--- a/src/app/(fullscreen)/home/questions/components/QuestionList.tsx
+++ b/src/app/(fullscreen)/home/questions/components/QuestionList.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Chip } from '@/components/ui/Chip';
+import { Button } from '@/components/ui/Button';
+import {
+  BottomDrawer,
+  BottomDrawerContent,
+  BottomDrawerFooter,
+  BottomDrawerHandle,
+  BottomDrawerHeader,
+} from '@/components/ui/Drawer';
+import { cn } from '@/utils/cn';
+import type { Question } from '@/types/memoirTypes';
+
+type FilterType = 'quick' | 'general';
+
+export default function QuestionList({ questions }: { questions: Question[] }) {
+  const [selectedFilter, setSelectedFilter] = useState<FilterType>('quick');
+  const [selectedQuestion, setSelectedQuestion] = useState<Question | null>(
+    null,
+  );
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  const filteredQuestions = questions.filter(question => {
+    if (selectedFilter === 'quick') {
+      return !question.answer;
+    }
+    return !!question.answer;
+  });
+
+  const handleQuestionClick = (question: Question) => {
+    if (question.answer) {
+      setSelectedQuestion(question);
+      setIsDrawerOpen(true);
+    }
+  };
+
+  const closeDrawer = () => {
+    setIsDrawerOpen(false);
+  };
+
+  return (
+    <div className="pb-8">
+      <header className="flex gap-2 py-8">
+        <Chip
+          text="퀵회고"
+          isSelected={selectedFilter === 'quick'}
+          onClick={() => setSelectedFilter('quick')}
+        />
+        <Chip
+          text="일반회고"
+          isSelected={selectedFilter === 'general'}
+          onClick={() => setSelectedFilter('general')}
+        />
+      </header>
+      <div className="space-y-4">
+        {filteredQuestions.map(question => (
+          <QuestionItem
+            key={question.id}
+            question={question}
+            onClick={() => handleQuestionClick(question)}
+          />
+        ))}
+      </div>
+
+      {selectedQuestion && (
+        <BottomDrawer isOpen={isDrawerOpen} onOpenChange={setIsDrawerOpen}>
+          <BottomDrawerHandle />
+          <BottomDrawerHeader title="회고 답변 상세" onClose={closeDrawer} />
+          <BottomDrawerContent className="px-4">
+            <div className="bg-foundation-box space-y-3 rounded-xl p-4">
+              <h3 className="typo-subhead-03">
+                <span className="text-secondary-btn">Q. </span>
+                <span className="text-foundation-primary">
+                  {selectedQuestion.content}
+                </span>
+              </h3>
+              <p className="text-foundation-secondary typo-body-long-01 break-keep">
+                {selectedQuestion.answer}
+              </p>
+            </div>
+          </BottomDrawerContent>
+          <BottomDrawerFooter>
+            <Button size="large" onClick={closeDrawer}>
+              닫기
+            </Button>
+          </BottomDrawerFooter>
+        </BottomDrawer>
+      )}
+    </div>
+  );
+}
+
+function QuestionItem({
+  question,
+  onClick,
+}: {
+  question: Question;
+  onClick: () => void;
+}) {
+  const isClickable = !!question.answer;
+
+  return (
+    <button
+      type="button"
+      disabled={!isClickable}
+      onClick={isClickable ? onClick : undefined}
+      className={cn(
+        'bg-foundation-box rounded-xl px-5 py-3 text-left',
+        isClickable && 'cursor-pointer',
+      )}
+    >
+      <h3 className={cn('typo-subhead-03', question.answer && 'mb-2')}>
+        <span className="text-secondary-btn">Q. </span>
+        <span className="text-foundation-primary">{question.content}</span>
+      </h3>
+      {question.answer && (
+        <p className="text-foundation-secondary typo-body-long-01 line-clamp-2 break-keep text-ellipsis">
+          {question.answer}
+        </p>
+      )}
+    </button>
+  );
+}

--- a/src/app/(fullscreen)/home/questions/components/RecentSearch.tsx
+++ b/src/app/(fullscreen)/home/questions/components/RecentSearch.tsx
@@ -1,0 +1,37 @@
+import DeleteIcon from '@/assets/icon/delete_icon.svg';
+import ClockIcon from '@/assets/icon/clock_icon.svg';
+
+export default function RecentSearch() {
+  const recentKeywords = ['갈등', '실패했을 때', '장단점'];
+
+  return (
+    <div className="py-4">
+      <div className="mb-6 flex items-center justify-between">
+        <h2 className="typo-subhead-long-03 text-foundation-primary">
+          최근 검색
+        </h2>
+        <button
+          type="button"
+          className="typo-body-long-01 text-foundation-secondary cursor-pointer"
+        >
+          전체 삭제
+        </button>
+      </div>
+
+      <ul className="space-y-2">
+        {recentKeywords.length > 0 &&
+          recentKeywords.map(keyword => (
+            <li key={keyword} className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <ClockIcon />
+                <span className="text-foundation-primary">{keyword}</span>
+              </div>
+              <button className="cursor-pointer">
+                <DeleteIcon />
+              </button>
+            </li>
+          ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/(fullscreen)/home/questions/experience/page.tsx
+++ b/src/app/(fullscreen)/home/questions/experience/page.tsx
@@ -1,6 +1,10 @@
 import { Metadata } from 'next';
 
 import { Header } from '@/components/ui/Header';
+import SearchIcon from '@/assets/icon/search_icon.svg';
+
+import QuestionList from '../components/QuestionList';
+import { mockQuestionCategory } from '../mocks/mockQuestionCategory';
 
 export const metadata: Metadata = {
   title: '경험질문',
@@ -10,7 +14,10 @@ export const metadata: Metadata = {
 export default function ExperienceQuestionsPage() {
   return (
     <>
-      <Header title="경험질문" />
+      <Header title="경험질문" rightContent={<SearchIcon />} />
+      <section className="px-5">
+        <QuestionList questions={mockQuestionCategory} />
+      </section>
     </>
   );
 }

--- a/src/app/(fullscreen)/home/questions/experience/page.tsx
+++ b/src/app/(fullscreen)/home/questions/experience/page.tsx
@@ -1,9 +1,6 @@
 import { Metadata } from 'next';
 
-import { Header } from '@/components/ui/Header';
-import SearchIcon from '@/assets/icon/search_icon.svg';
-
-import QuestionList from '../components/QuestionList';
+import QuestionContainer from '../components/QuestionContainer';
 import { mockQuestionCategory } from '../mocks/mockQuestionCategory';
 
 export const metadata: Metadata = {
@@ -14,10 +11,10 @@ export const metadata: Metadata = {
 export default function ExperienceQuestionsPage() {
   return (
     <>
-      <Header title="경험질문" rightContent={<SearchIcon />} />
-      <section className="px-5">
-        <QuestionList questions={mockQuestionCategory} />
-      </section>
+      <QuestionContainer
+        initialQuestions={mockQuestionCategory}
+        title="경험질문"
+      />
     </>
   );
 }

--- a/src/app/(fullscreen)/home/questions/follow-up/page.tsx
+++ b/src/app/(fullscreen)/home/questions/follow-up/page.tsx
@@ -1,9 +1,6 @@
 import { Metadata } from 'next';
 
-import { Header } from '@/components/ui/Header';
-import SearchIcon from '@/assets/icon/search_icon.svg';
-
-import QuestionList from '../components/QuestionList';
+import QuestionContainer from '../components/QuestionContainer';
 import { mockQuestionCategory } from '../mocks/mockQuestionCategory';
 
 export const metadata: Metadata = {
@@ -14,10 +11,10 @@ export const metadata: Metadata = {
 export default function FollowUpQuestionsPage() {
   return (
     <>
-      <Header title="꼬리질문" rightContent={<SearchIcon />} />
-      <section className="px-5">
-        <QuestionList questions={mockQuestionCategory} />
-      </section>
+      <QuestionContainer
+        initialQuestions={mockQuestionCategory}
+        title="꼬리질문"
+      />
     </>
   );
 }

--- a/src/app/(fullscreen)/home/questions/follow-up/page.tsx
+++ b/src/app/(fullscreen)/home/questions/follow-up/page.tsx
@@ -1,6 +1,10 @@
 import { Metadata } from 'next';
 
 import { Header } from '@/components/ui/Header';
+import SearchIcon from '@/assets/icon/search_icon.svg';
+
+import QuestionList from '../components/QuestionList';
+import { mockQuestionCategory } from '../mocks/mockQuestionCategory';
 
 export const metadata: Metadata = {
   title: '꼬리질문',
@@ -10,7 +14,10 @@ export const metadata: Metadata = {
 export default function FollowUpQuestionsPage() {
   return (
     <>
-      <Header title="꼬리질문" />
+      <Header title="꼬리질문" rightContent={<SearchIcon />} />
+      <section className="px-5">
+        <QuestionList questions={mockQuestionCategory} />
+      </section>
     </>
   );
 }

--- a/src/app/(fullscreen)/home/questions/job/page.tsx
+++ b/src/app/(fullscreen)/home/questions/job/page.tsx
@@ -1,9 +1,6 @@
 import { Metadata } from 'next';
 
-import { Header } from '@/components/ui/Header';
-import SearchIcon from '@/assets/icon/search_icon.svg';
-
-import QuestionList from '../components/QuestionList';
+import QuestionContainer from '../components/QuestionContainer';
 import { mockQuestionCategory } from '../mocks/mockQuestionCategory';
 
 export const metadata: Metadata = {
@@ -14,10 +11,10 @@ export const metadata: Metadata = {
 export default function JobQuestionsPage() {
   return (
     <>
-      <Header title="직무질문" rightContent={<SearchIcon />} />
-      <section className="px-5">
-        <QuestionList questions={mockQuestionCategory} />
-      </section>
+      <QuestionContainer
+        initialQuestions={mockQuestionCategory}
+        title="직무질문"
+      />
     </>
   );
 }

--- a/src/app/(fullscreen)/home/questions/job/page.tsx
+++ b/src/app/(fullscreen)/home/questions/job/page.tsx
@@ -1,6 +1,10 @@
 import { Metadata } from 'next';
 
 import { Header } from '@/components/ui/Header';
+import SearchIcon from '@/assets/icon/search_icon.svg';
+
+import QuestionList from '../components/QuestionList';
+import { mockQuestionCategory } from '../mocks/mockQuestionCategory';
 
 export const metadata: Metadata = {
   title: '직무질문',
@@ -10,7 +14,10 @@ export const metadata: Metadata = {
 export default function JobQuestionsPage() {
   return (
     <>
-      <Header title="직무질문" />
+      <Header title="직무질문" rightContent={<SearchIcon />} />
+      <section className="px-5">
+        <QuestionList questions={mockQuestionCategory} />
+      </section>
     </>
   );
 }

--- a/src/app/(fullscreen)/home/questions/mocks/mockQuestionCategory.ts
+++ b/src/app/(fullscreen)/home/questions/mocks/mockQuestionCategory.ts
@@ -1,0 +1,100 @@
+import type { Question } from '@/types/memoirTypes';
+import { QUESTION_TYPE } from '@/constants/code';
+
+export const mockQuestionCategory: Question[] = [
+  {
+    id: 1,
+    questionType: QUESTION_TYPE.PERSONALITY,
+    content: '1분 자기소개를 부탁드립니다.',
+    answer:
+      '안녕하세요, 끊임없이 배우고 성장하는 개발자 OOO입니다. 저는 JavaScript와 TypeScript에 대한 깊은 이해를 바탕으로 React 환경에서 사용자 중심의 웹 애플리케이션을 개발해왔습니다. 특히 팀원들과의 원활한 소통과 협업을 중요하게 생각하며, 귀사의 서비스 가치를 높이는 데 기여하고 싶습니다.',
+    displayOrder: 1,
+  },
+  {
+    id: 2,
+    questionType: QUESTION_TYPE.COMPANY,
+    content: '우리 회사에 지원하게 된 동기는 무엇인가요?',
+    answer:
+      '귀사는 혁신적인 기술을 통해 꾸준히 시장을 선도하고 있으며, 특히 OOO 프로젝트에서 보여준 사용자 경험에 대한 깊은 고민에 큰 감명을 받았습니다. 저의 기술 스택과 성장 방향성이 귀사의 비전과 일치한다고 생각하여, 함께 성장하고 싶다는 생각에 지원하게 되었습니다.',
+    displayOrder: 2,
+  },
+  {
+    id: 3,
+    questionType: QUESTION_TYPE.JOB,
+    content: '지원하신 직무에 가장 중요한 역량은 무엇이라고 생각하시나요?',
+    answer: null,
+    displayOrder: 3,
+  },
+  {
+    id: 4,
+    questionType: QUESTION_TYPE.EXPERIENCE,
+    content: '팀원들과 협업하여 문제를 해결했던 경험에 대해 말씀해주세요.',
+    answer:
+      '이전 프로젝트 진행 중, 예상치 못한 API 변경으로 인해 전체 기능이 마비된 적이 있습니다. 당시 프론트엔드 팀원들과 빠르게 현재 상황을 공유하고, 백엔드 팀과 긴급 회의를 소집하여 문제의 원인을 파악했습니다. 저는 임시 목업 데이터를 생성하여 다른 팀원들의 UI 작업을 지원하는 동시에, 백엔드 팀과 소통하며 새로운 API 명세에 맞춰 코드를 수정하여 하루 만에 문제를 해결한 경험이 있습니다.',
+    displayOrder: 4,
+  },
+  {
+    id: 5,
+    questionType: QUESTION_TYPE.PERSONALITY,
+    content:
+      '본인의 장점과 단점은 무엇이며, 단점을 극복하기 위해 어떤 노력을 했나요?',
+    answer: null,
+    displayOrder: 5,
+  },
+  {
+    id: 6,
+    questionType: QUESTION_TYPE.EXPERIENCE,
+    content:
+      '살면서 가장 큰 도전을 했던 경험은 무엇인가요? 그 경험을 통해 무엇을 배웠나요?',
+    answer: null,
+    displayOrder: 6,
+  },
+  {
+    id: 7,
+    questionType: QUESTION_TYPE.COMPANY,
+    content:
+      '입사 후 우리 회사에서 이루고 싶은 목표나 포부가 있다면 무엇인가요?',
+    answer:
+      '단기적으로는 회사의 개발 문화와 프로세스에 빠르게 적응하여 팀에 기여하는 것이 목표입니다. 장기적으로는 제가 가진 프론트엔드 역량을 바탕으로 서비스의 성능을 개선하고 사용자 만족도를 높이는 핵심적인 역할을 수행하고 싶습니다.',
+    displayOrder: 7,
+  },
+  {
+    id: 8,
+    questionType: QUESTION_TYPE.JOB,
+    content:
+      '해당 직무를 수행하기 위해 어떤 준비와 노력을 해왔는지 구체적으로 말씀해주세요.',
+    answer: null,
+    displayOrder: 8,
+  },
+  {
+    id: 9,
+    questionType: QUESTION_TYPE.PERSONALITY,
+    content: '상사와 의견 충돌이 발생했을 때 어떻게 대처하시겠습니까?',
+    answer: null,
+    displayOrder: 9,
+  },
+  {
+    id: 10,
+    questionType: QUESTION_TYPE.COMPANY,
+    content:
+      '마지막으로 하고 싶은 말이나 궁금한 점이 있다면 편하게 질문해주세요.',
+    answer:
+      '네, 저는 팀의 기술 블로그를 인상 깊게 보았습니다. 혹시 입사하게 된다면 신입 사원도 기술 공유나 스터디 활동에 적극적으로 참여할 수 있는 기회가 있는지 궁금합니다.',
+    displayOrder: 10,
+  },
+  {
+    id: 11,
+    questionType: QUESTION_TYPE.FOLLOW_UP,
+    content:
+      '방금 말씀하신 경험에서 본인이 맡았던 역할은 구체적으로 무엇이었나요?',
+    answer: null,
+    displayOrder: 11,
+  },
+  {
+    id: 12,
+    questionType: QUESTION_TYPE.FOLLOW_UP,
+    content: '그 결정으로 인해 어떤 결과가 있었나요? 예상했던 결과였나요?',
+    answer: null,
+    displayOrder: 12,
+  },
+];

--- a/src/app/(fullscreen)/home/questions/personality/page.tsx
+++ b/src/app/(fullscreen)/home/questions/personality/page.tsx
@@ -1,9 +1,6 @@
 import { Metadata } from 'next';
 
-import { Header } from '@/components/ui/Header';
-import SearchIcon from '@/assets/icon/search_icon.svg';
-
-import QuestionList from '../components/QuestionList';
+import QuestionContainer from '../components/QuestionContainer';
 import { mockQuestionCategory } from '../mocks/mockQuestionCategory';
 
 export const metadata: Metadata = {
@@ -14,10 +11,10 @@ export const metadata: Metadata = {
 export default function PersonalityQuestionsPage() {
   return (
     <>
-      <Header title="인성질문" rightContent={<SearchIcon />} />
-      <section className="px-5">
-        <QuestionList questions={mockQuestionCategory} />
-      </section>
+      <QuestionContainer
+        initialQuestions={mockQuestionCategory}
+        title="인성질문"
+      />
     </>
   );
 }

--- a/src/app/(fullscreen)/home/questions/personality/page.tsx
+++ b/src/app/(fullscreen)/home/questions/personality/page.tsx
@@ -1,6 +1,10 @@
 import { Metadata } from 'next';
 
 import { Header } from '@/components/ui/Header';
+import SearchIcon from '@/assets/icon/search_icon.svg';
+
+import QuestionList from '../components/QuestionList';
+import { mockQuestionCategory } from '../mocks/mockQuestionCategory';
 
 export const metadata: Metadata = {
   title: '인성질문',
@@ -10,7 +14,10 @@ export const metadata: Metadata = {
 export default function PersonalityQuestionsPage() {
   return (
     <>
-      <Header title="인성질문" />
+      <Header title="인성질문" rightContent={<SearchIcon />} />
+      <section className="px-5">
+        <QuestionList questions={mockQuestionCategory} />
+      </section>
     </>
   );
 }

--- a/src/app/(root)/home/components/QuestionCategory.tsx
+++ b/src/app/(root)/home/components/QuestionCategory.tsx
@@ -24,7 +24,9 @@ export default function QuestionCategory() {
           href={category.path}
           className="flex flex-col items-center gap-0.5"
         >
-          {category.icon}
+          <div className="bg-foundation-box rounded-full p-3">
+            {category.icon}
+          </div>
           <span className="typo-body-long-01 text-white">{category.label}</span>
         </Link>
       ))}

--- a/src/assets/icon/clock_icon.svg
+++ b/src/assets/icon/clock_icon.svg
@@ -1,0 +1,11 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1133_31793)">
+<path d="M9 16.5C13.1421 16.5 16.5 13.1421 16.5 9C16.5 4.85786 13.1421 1.5 9 1.5C4.85786 1.5 1.5 4.85786 1.5 9C1.5 13.1421 4.85786 16.5 9 16.5Z" stroke="#888888" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 4.5V9L12 10.5" stroke="#888888" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_1133_31793">
+<rect width="18" height="18" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/icon/delete_icon.svg
+++ b/src/assets/icon/delete_icon.svg
@@ -1,0 +1,4 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.5 4.5L4.5 13.5" stroke="#888888" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.5 4.5L13.5 13.5" stroke="#888888" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -6,7 +6,7 @@ import LeftArrowIcon from '@/assets/icon/left_arrow_icon.svg';
 import { cn } from '@/utils/cn';
 
 interface Props {
-  title: string;
+  title: ReactNode;
   rightContent?: ReactNode | string;
   onBackClick?: () => void;
   onRightClick?: () => void;
@@ -29,35 +29,49 @@ function Header({
   };
 
   return (
-    <header className="border-foundation-divider relative border py-6">
+    <header
+      className={cn(
+        'border-foundation-divider flex items-center border px-4',
+        typeof title === 'string' ? 'py-6' : 'py-3',
+      )}
+    >
       {showBackButton && (
-        <LeftArrowIcon
-          className="absolute top-1/2 left-6 -translate-y-1/2 cursor-pointer"
-          aria-label="뒤로 가기"
-          onClick={handleBackClick}
-        />
+        <div className="w-8 shrink-0">
+          <LeftArrowIcon
+            className="shrink-0 cursor-pointer"
+            aria-label="뒤로 가기"
+            onClick={handleBackClick}
+          />
+        </div>
       )}
 
-      <div className={cn('text-center', !showBackButton && 'px-6')}>
-        <span className="typo-headline text-foundation-strong">{title}</span>
+      <div className="flex-1 text-center">
+        {typeof title === 'string' ? (
+          <span className="typo-headline text-foundation-strong">{title}</span>
+        ) : (
+          title
+        )}
       </div>
 
-      <div
-        className={cn(
-          'absolute top-1/2 right-6 flex -translate-y-1/2 items-center',
-          onRightClick && 'cursor-pointer',
-        )}
-        onClick={onRightClick}
-      >
-        {rightContent &&
-          (typeof rightContent === 'string' ? (
+      {rightContent ? (
+        <div
+          className={cn(
+            'flex w-8 flex-shrink-0 justify-end',
+            onRightClick && 'cursor-pointer',
+          )}
+          onClick={onRightClick}
+        >
+          {typeof rightContent === 'string' ? (
             <span className="typo-body-02 text-foundation-strong">
               {rightContent}
             </span>
           ) : (
             rightContent
-          ))}
-      </div>
+          )}
+        </div>
+      ) : showBackButton ? (
+        <div className="w-8 shrink-0" />
+      ) : null}
     </header>
   );
 }

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -41,12 +41,12 @@ function Input({
           )}
           {...props}
         />
-        {onClear && value && icons && (
+        {onClear && icons && (
           <button
             type="button"
             onClick={onClear}
             aria-label="Clear input"
-            className="shrink-0 cursor-pointer"
+            className={cn('shrink-0 cursor-pointer', !value && 'invisible')}
           >
             {icons}
           </button>


### PR DESCRIPTION
## 🔗 Related Issue

- close #51 
- ref #51

---

## ✨ What’s this PR?

<!-- 어떤 기능/수정인지 간단히 설명해주세요 -->
질문 카테고리 5개에 대한 페이지를 제작했어요.

---

## ✅ Done

- [x] 홈 화면에서 보이는 질문 카테고리 스타일을 수정했어요.
- [x] 카테고리별 질문의 `item`, `list` 컴포넌트를 제작했어요.
- [x] 카테고리별 질문 페이지를 제작했어요.
- [x] `Input` 컴포넌트에서 입력 시 `X` 아이콘 등장으로 layout shift 되는 현상을 막았어요.
- [x] 최근 검색 컴포넌트를 제작했어요.
- [x] `Header` 컴포넌트 스타일을 수정했어요.
- [x] 질문 카테고리에서 검색이 가능하도록 컴포넌트를 제작하고 적용했어요.      

---

## 💬 Notes for Reviewer

<!-- 리뷰어가 확인했으면 하는 포인트, 의문점, 논의할 사항 등을 자유롭게 작성해주세요 -->
- 논의할 사항 등을 자유롭게 작성해주세요.

---

## 📷 Screenshot / Demo
![pc](https://example.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified Questions experience with a searchable container, filterable lists (answered/unanswered), and a bottom drawer for details.
  * Introduced a Recent Search view.
* **Refactor**
  * Replaced static headers on question pages with the new container using a mock data source.
* **Style**
  * Category icons now display within a rounded background.
  * Header layout refined with an optional back button and flexible title content.
  * Input clear button remains positioned but becomes invisible when the field is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->