### PR TITLE
[✨ feat] 일정 상세 조회 페이지 제작 (#55)

### DIFF
--- a/src/apis/schedule/scheduleDetailApi.ts
+++ b/src/apis/schedule/scheduleDetailApi.ts
@@ -1,0 +1,11 @@
+import { mockScheduleDetailResponse } from '@/app/(fullscreen)/schedule/[slug]/mocks/mockScheduleDetailResponse';
+import type { ScheduleDetailResponse } from '@/types/scheduleTypes';
+
+export async function getScheduleDetail(
+  _id: string,
+): Promise<ScheduleDetailResponse> {
+  // const response = await axios.get(`/schedules/${id}`);
+  // return response.data
+
+  return mockScheduleDetailResponse;
+}

--- a/src/app/(fullscreen)/home/memoir/[slug]/page.tsx
+++ b/src/app/(fullscreen)/home/memoir/[slug]/page.tsx
@@ -1,8 +1,15 @@
+import { Metadata } from 'next';
+
 import { getMemoirDetail } from '@/apis/memoir/memoirDetailApi';
 import { Header } from '@/components/ui/Header';
 
 import MemoirDetailContent from './components/MemoirDetailContent';
 import MemoirDetailAction from './components/MemoirDetailAction';
+
+export const metadata: Metadata = {
+  title: '면접 회고 상세',
+  description: '면접에 대한 상세한 회고를 확인해보세요.',
+};
 
 interface Params {
   params: {

--- a/src/app/(fullscreen)/schedule/[slug]/components/ScheduleDetailContent.tsx
+++ b/src/app/(fullscreen)/schedule/[slug]/components/ScheduleDetailContent.tsx
@@ -1,0 +1,37 @@
+import { Title } from '@/components/ui/Title';
+import { formatDateToYYMMDDHHMM } from '@/utils/date';
+import type { ScheduleDetailData } from '@/types/scheduleTypes';
+
+interface Props {
+  data: ScheduleDetailData;
+}
+
+export default function ScheduleDetailContent({ data }: Props) {
+  return (
+    <div className="py-8">
+      <Title title={data.companyName} className="mb-5" />
+      <section>
+        <div className="bg-foundation-box rounded-xl px-5 py-4">
+          <div className="flex flex-col gap-2">
+            <InfoRow label="직무" content={data.position} />
+            <InfoRow
+              label="면접일"
+              content={formatDateToYYMMDDHHMM(data.interviewDate)}
+            />
+            <InfoRow label="면접장소" content={data.location} />
+            <InfoRow label="면접유형" content={data.interviewStep} />
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function InfoRow({ label, content }: { label: string; content: string }) {
+  return (
+    <div className="text-foundation-primary typo-body-02 flex items-start gap-3">
+      <span className="shrink-0">{label}</span>
+      <span>{content}</span>
+    </div>
+  );
+}

--- a/src/app/(fullscreen)/schedule/[slug]/components/ScheduleDetailView.tsx
+++ b/src/app/(fullscreen)/schedule/[slug]/components/ScheduleDetailView.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useState } from 'react';
+
+import MoreIcon from '@/assets/icon/more_icon.svg';
+import { Header } from '@/components/ui/Header';
+import {
+  BottomDrawer,
+  BottomDrawerContent,
+  BottomDrawerFooter,
+  BottomDrawerHandle,
+  BottomDrawerHeader,
+} from '@/components/ui/Drawer';
+import { Button } from '@/components/ui/Button';
+import { cn } from '@/utils/cn';
+import type { ScheduleDetailData } from '@/types/scheduleTypes';
+
+import ScheduleDetailContent from './ScheduleDetailContent';
+
+interface Props {
+  data: ScheduleDetailData;
+}
+
+export default function ScheduleDetailView({ data }: Props) {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  const handleEdit = () => {
+    // router.push(PATH.SCHEDULE.EDIT.path.replace('[id]', String(data.id)));
+    setIsDrawerOpen(false);
+  };
+
+  const handleDelete = () => {
+    // if (confirm('정말로 이 일정을 삭제하시겠습니까?')) {
+    //   // deleteApi(data.id);
+    // }
+    setIsDrawerOpen(false);
+  };
+
+  const menuItems = [
+    { id: 'edit', label: '수정', onClick: handleEdit },
+    { id: 'delete', label: '삭제', onClick: handleDelete },
+  ];
+
+  return (
+    <div className="flex h-screen flex-col">
+      <Header
+        title="일정"
+        rightContent={<MoreIcon className="cursor-pointer" />}
+        onRightClick={() => setIsDrawerOpen(true)}
+      />
+      <main className="no-scrollbar flex-1 overflow-y-auto">
+        <div className="px-5">
+          <ScheduleDetailContent data={data} />
+        </div>
+      </main>
+
+      <BottomDrawer isOpen={isDrawerOpen} onOpenChange={setIsDrawerOpen}>
+        <BottomDrawerHandle />
+        <BottomDrawerHeader
+          title="옵션"
+          onClose={() => setIsDrawerOpen(false)}
+        />
+        <BottomDrawerContent className="px-4">
+          <div className="bg-gray-btn flex cursor-pointer flex-col rounded-lg px-5 py-3">
+            {menuItems.map(item => {
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={item.onClick}
+                  className={cn(
+                    'bg-gray-btn cursor-pointer p-2.5',
+                    item.id === 'edit' && 'border-foundation-divider border-b',
+                  )}
+                >
+                  <span
+                    className={cn(
+                      'typo-body-02',
+                      item.id === 'delete'
+                        ? 'text-warning'
+                        : 'text-foundation-primary',
+                    )}
+                  >
+                    {item.label}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </BottomDrawerContent>
+        <BottomDrawerFooter>
+          <Button
+            variant="secondary"
+            size="large"
+            onClick={() => setIsDrawerOpen(false)}
+          >
+            닫기
+          </Button>
+        </BottomDrawerFooter>
+      </BottomDrawer>
+    </div>
+  );
+}

--- a/src/app/(fullscreen)/schedule/[slug]/mocks/mockScheduleDetailResponse.ts
+++ b/src/app/(fullscreen)/schedule/[slug]/mocks/mockScheduleDetailResponse.ts
@@ -1,0 +1,14 @@
+import type { ScheduleDetailResponse } from '@/types/scheduleTypes';
+
+export const mockScheduleDetailResponse: ScheduleDetailResponse = {
+  code: '200',
+  message: '일정 상세 조회에 성공했습니다.',
+  data: {
+    id: 1,
+    companyName: '네이버',
+    position: '프론트엔드 개발자',
+    interviewDate: '2025-08-25T14:00:00.000Z',
+    interviewStep: '1차 면접',
+    location: '경기도 성남시 분당구 불정로 6 네이버 그린팩토리',
+  },
+};

--- a/src/app/(fullscreen)/schedule/[slug]/page.tsx
+++ b/src/app/(fullscreen)/schedule/[slug]/page.tsx
@@ -1,0 +1,24 @@
+import { Metadata } from 'next';
+
+import { getScheduleDetail } from '@/apis/schedule/scheduleDetailApi';
+
+import ScheduleDetailView from './components/ScheduleDetailView';
+
+export const metadata: Metadata = {
+  title: '일정 상세',
+  description: '면접에 대한 상세한 일정을 확인해보세요.',
+};
+
+interface Params {
+  params: {
+    id: string;
+  };
+}
+
+export default async function ScheduleDetailPage({ params }: Params) {
+  const { id } = params;
+  const response = await getScheduleDetail(id);
+  const scheduleData = response.data;
+
+  return <ScheduleDetailView data={scheduleData} />;
+}

--- a/src/app/(root)/schedule/components/ScheduleItem.tsx
+++ b/src/app/(root)/schedule/components/ScheduleItem.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 import { Badge } from '@/components/ui/Badge';
 import { cn } from '@/utils/cn';
@@ -16,7 +17,10 @@ const memoirTypeStyles: Record<string, { text: string; className: string }> = {
 };
 
 export default function ScheduleItem({ schedule }: Props) {
+  const router = useRouter();
+
   const {
+    id,
     companyName,
     position,
     interviewDate,
@@ -26,6 +30,10 @@ export default function ScheduleItem({ schedule }: Props) {
   } = schedule;
 
   const formattedDate = formatDateToYYMMDDHHMM(interviewDate);
+
+  const handleNavigateToDetail = () => {
+    router.push(PATH.SCHEDULE.DETAIL.path.replace('[id]', String(id)));
+  };
 
   const StatusDisplay = (() => {
     const isUpcoming = typeof remainDate === 'number' && remainDate >= 0;
@@ -45,7 +53,7 @@ export default function ScheduleItem({ schedule }: Props) {
     }
     if (needsMemoir) {
       return (
-        <Link href={PATH.MEMOIR.CREATE.path}>
+        <Link href={PATH.MEMOIR.CREATE.path} onClick={e => e.stopPropagation()}>
           <Badge>{PATH.MEMOIR.CREATE.label}</Badge>
         </Link>
       );
@@ -54,46 +62,48 @@ export default function ScheduleItem({ schedule }: Props) {
   })();
 
   return (
-    <div className="bg-foundation-box rounded-xl px-5 py-3">
-      <div className="flex items-center gap-3">
-        {memoirTypes && memoirTypes.length > 0 && (
-          <div className="flex items-center gap-1">
-            {memoirTypes.map(type => (
-              <Badge
-                key={type}
-                shape="minimal"
-                size="xsmall"
-                className={memoirTypeStyles[type].className}
-              >
-                {memoirTypeStyles[type].text}
-              </Badge>
-            ))}
+    <div onClick={handleNavigateToDetail} className="cursor-pointer">
+      <div className="bg-foundation-box rounded-xl px-5 py-3">
+        <div className="flex items-center gap-3">
+          {memoirTypes && memoirTypes.length > 0 && (
+            <div className="flex items-center gap-1">
+              {memoirTypes.map(type => (
+                <Badge
+                  key={type}
+                  shape="minimal"
+                  size="xsmall"
+                  className={memoirTypeStyles[type].className}
+                >
+                  {memoirTypeStyles[type].text}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          <div className="flex items-center gap-[6px]">
+            <h3 className="text-foundation-primary typo-subhead-long-03">
+              {companyName}
+            </h3>
+            <span className="typo-subhead-02 text-foundation-disabled">|</span>
+            <p className="text-foundation-primary typo-subhead-long-03">
+              {position}
+            </p>
           </div>
-        )}
-
-        <div className="flex items-center gap-[6px]">
-          <h3 className="text-foundation-primary typo-subhead-long-03">
-            {companyName}
-          </h3>
-          <span className="typo-subhead-02 text-foundation-disabled">|</span>
-          <p className="text-foundation-primary typo-subhead-long-03">
-            {position}
-          </p>
-        </div>
-      </div>
-
-      <div className="flex items-end justify-between">
-        <div className="space-x-2">
-          <span className="typo-body-long-01 text-foundation-disabled">
-            면접일 : {formattedDate}
-          </span>
-          <span className="typo-subhead-02 text-foundation-disabled">|</span>
-          <span className="typo-body-long-01 text-foundation-disabled">
-            {interviewStep}
-          </span>
         </div>
 
-        {StatusDisplay}
+        <div className="flex items-end justify-between">
+          <div className="space-x-2">
+            <span className="typo-body-long-01 text-foundation-disabled">
+              면접일 : {formattedDate}
+            </span>
+            <span className="typo-subhead-02 text-foundation-disabled">|</span>
+            <span className="typo-body-long-01 text-foundation-disabled">
+              {interviewStep}
+            </span>
+          </div>
+
+          {StatusDisplay}
+        </div>
       </div>
     </div>
   );

--- a/src/assets/icon/more_icon.svg
+++ b/src/assets/icon/more_icon.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 13C12.5523 13 13 12.5523 13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12C11 12.5523 11.4477 13 12 13Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 6C12.5523 6 13 5.55228 13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5C11 5.55228 11.4477 6 12 6Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 20C12.5523 20 13 19.5523 13 19C13 18.4477 12.5523 18 12 18C11.4477 18 11 18.4477 11 19C11 19.5523 11.4477 20 12 20Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -35,5 +35,6 @@ export const PATH = {
   SCHEDULE: {
     HOME: { path: '/schedule', label: '일정' },
     NEW: { path: '/schedule/new', label: '면접 일정 등록' },
+    DETAIL: { path: '/schedule/[id]', label: '일정 상세' },
   },
 } as const;

--- a/src/types/scheduleTypes.ts
+++ b/src/types/scheduleTypes.ts
@@ -1,6 +1,6 @@
 import { InterviewStep, MemoirType, Position } from './memoirTypes';
 
-// 일정 단건
+// 일정 아이템
 export interface Schedule {
   id: number;
   companyName: string;
@@ -26,4 +26,21 @@ export interface ScheduleCreate {
   interviewDateTime: string;
   location: string;
   interviewStep: InterviewStep | string;
+}
+
+// 일정 단건 조회 데이터
+export interface ScheduleDetailData {
+  id: number;
+  companyName: string;
+  position: Position | string;
+  interviewDate: string;
+  interviewStep: InterviewStep | string;
+  location: string;
+}
+
+// 일정 단건 조회 응답 (상세)
+export interface ScheduleDetailResponse {
+  code: string;
+  message: string;
+  data: ScheduleDetailData;
 }


### PR DESCRIPTION
## 🔗 Related Issue

- close #55 
- ref #55

---

## ✨ What’s this PR?

<!-- 어떤 기능/수정인지 간단히 설명해주세요 -->
일정 상세 조회 페이지를 제작했어요.

---

## ✅ Done

- [x] 일정 조회 상세 타입 정의 및 목데이터 추가
- [x] `ScheduleItem`에서 클릭 시 일정 상세 페이지로 이동하도록 추가
- [x] 일정 상세 페이지 제작 

---

## 💬 Notes for Reviewer

<!-- 리뷰어가 확인했으면 하는 포인트, 의문점, 논의할 사항 등을 자유롭게 작성해주세요 -->
- 논의할 사항 등을 자유롭게 작성해주세요.

---

## 📷 Screenshot / Demo
![pc](https://example.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a schedule detail page displaying company, role, interview date/time, location, and interview step.
  - Added an action drawer on the detail page with Edit and Delete options.
  - Enabled tap-to-open: schedule list cards are now fully clickable to open their details.
  - Updated page titles and descriptions for clearer context.

- Bug Fixes
  - Prevented unintended navigation when tapping the Memoir link inside a schedule card.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->