### PR TITLE
[✨ design] overflow시 배경 잘리는 스타일 수정 (#59)

### DIFF
--- a/src/app/(fullscreen)/home/memoir/hot/page.tsx
+++ b/src/app/(fullscreen)/home/memoir/hot/page.tsx
@@ -3,7 +3,7 @@ import SearchIcon from '@/assets/icon/search_icon.svg';
 
 export default function WeeklyHotMemoirPage() {
   return (
-    <main className="flex h-screen flex-col">
+    <main className="flex min-h-screen flex-col">
       <Header title="이번주 HOT 회고" rightContent={<SearchIcon />} />
     </main>
   );

--- a/src/app/(fullscreen)/home/questions/components/QuestionContainer.tsx
+++ b/src/app/(fullscreen)/home/questions/components/QuestionContainer.tsx
@@ -55,7 +55,7 @@ export default function QuestionContainer({ initialQuestions, title }: Props) {
   };
 
   return (
-    <div className="flex h-dvh flex-col">
+    <div className="flex min-h-dvh flex-col">
       <Header
         onBackClick={isSearching ? handleCancelSearch : undefined}
         title={

--- a/src/app/(fullscreen)/my-page/comments/page.tsx
+++ b/src/app/(fullscreen)/my-page/comments/page.tsx
@@ -5,9 +5,9 @@ import { mockMemoirs } from '../mocks/memoir';
 
 export default function MyCommentsPage() {
   return (
-    <main className="flex h-screen flex-col">
+    <main className="flex min-h-screen flex-col">
       <Header title="내가 댓글 남긴 글" />
-      <div className="mt-8">
+      <div className="my-8">
         <MemoirList memoirs={mockMemoirs} emptyText="작성한 댓글이 없어요." />
       </div>
     </main>

--- a/src/app/(fullscreen)/my-page/components/MemoirList.tsx
+++ b/src/app/(fullscreen)/my-page/components/MemoirList.tsx
@@ -12,7 +12,7 @@ interface Props {
 export default function MemoirList({ memoirs, hideBadge, emptyText }: Props) {
   return (
     <>
-      <div className="flex flex-1 flex-col gap-3 px-5">
+      <div className="mb-5 flex flex-1 flex-col gap-3 px-5">
         {memoirs.length > 0 ? (
           memoirs.map(memoir => (
             <MemoirItem key={memoir.id} memoir={memoir} hideBadge={hideBadge} />

--- a/src/app/(fullscreen)/my-page/likes/page.tsx
+++ b/src/app/(fullscreen)/my-page/likes/page.tsx
@@ -5,9 +5,9 @@ import { mockMemoirs } from '../mocks/memoir';
 
 export default function MyLikesPage() {
   return (
-    <main className="flex h-screen flex-col">
+    <main className="flex min-h-screen flex-col">
       <Header title="내가 좋아요한 글" />
-      <div className="mt-8">
+      <div className="my-8">
         <MemoirList memoirs={mockMemoirs} emptyText="좋아요한 글이 없어요." />
       </div>
     </main>

--- a/src/app/(fullscreen)/my-page/memoirs/page.tsx
+++ b/src/app/(fullscreen)/my-page/memoirs/page.tsx
@@ -4,7 +4,7 @@ import MyMemoirsView from '../components/MyMemoirsView';
 
 export default function MyMemoirsPage() {
   return (
-    <main className="flex h-screen flex-col">
+    <main className="flex min-h-screen flex-col">
       <Header title="나의 회고 리스트" />
       <MyMemoirsView />
     </main>

--- a/src/app/(fullscreen)/my-page/profile-modify/components/ProfileModifyView.tsx
+++ b/src/app/(fullscreen)/my-page/profile-modify/components/ProfileModifyView.tsx
@@ -38,7 +38,7 @@ export default function ProfileModifyView({ initialNickname }: Props) {
   };
 
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex min-h-screen flex-col">
       <Header
         title="프로필 편집"
         rightContent="완료"

--- a/src/app/(fullscreen)/my-page/scrap/page.tsx
+++ b/src/app/(fullscreen)/my-page/scrap/page.tsx
@@ -5,9 +5,9 @@ import { mockMemoirs } from '../mocks/memoir';
 
 export default function MyScrapPage() {
   return (
-    <main className="flex h-screen flex-col">
+    <main className="flex min-h-screen flex-col">
       <Header title="내가 스크랩한 글" />
-      <div className="mt-8">
+      <div className="my-8">
         <MemoirList memoirs={mockMemoirs} emptyText="스크랩한 글이 없어요." />
       </div>
     </main>

--- a/src/app/(fullscreen)/my-page/temp-saved/page.tsx
+++ b/src/app/(fullscreen)/my-page/temp-saved/page.tsx
@@ -5,9 +5,9 @@ import { mockMemoirs } from '../mocks/memoir';
 
 export default function TempSavedPage() {
   return (
-    <main className="flex h-screen flex-col">
+    <main className="flex min-h-screen flex-col">
       <Header title="임시 저장한 글" />
-      <div className="mt-8">
+      <div className="my-8">
         <MemoirList
           memoirs={mockMemoirs}
           hideBadge={true}

--- a/src/app/(root)/schedule/page.tsx
+++ b/src/app/(root)/schedule/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 
 export default function SchedulePage() {
   return (
-    <main className="flex h-screen flex-col">
+    <main className="flex min-h-screen flex-col">
       <Header title="일정" showBackButton={false} />
       <ScheduleView />
     </main>

--- a/src/components/onboarding/Onboarding.tsx
+++ b/src/components/onboarding/Onboarding.tsx
@@ -14,7 +14,7 @@ export default function Onboarding() {
   };
 
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex min-h-screen flex-col">
       <section className="flex flex-1 flex-col justify-center px-[30px]">
         <Logo width={25} height={39} />
         <h1 className="typo-display-02 text-foundation-strong mt-6">
@@ -26,7 +26,7 @@ export default function Onboarding() {
         </span>
       </section>
 
-      <footer className="px-5 pb-8">
+      <footer className="mb-8 px-5">
         <Button
           variant="yellow"
           className="flex items-center gap-1 rounded-full"

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -31,7 +31,7 @@ function Header({
   return (
     <header
       className={cn(
-        'border-foundation-divider flex items-center border px-4',
+        'border-foundation-divider flex items-center border-b px-4',
         typeof title === 'string' ? 'py-6' : 'py-3',
       )}
     >


### PR DESCRIPTION
## 🔗 Related Issue

- close #59
- ref #59

---

## ✨ What’s this PR?

<!-- 어떤 기능/수정인지 간단히 설명해주세요 -->
내부 콘텐츠가 화면보다 길어져 스크롤이 길어지면 div 자체의 높이는 늘어나지 않아서 콘텐츠 길이에 맞게 길어지도록 수정해요.

---

## ✅ Done

- [x] 스타일 수정

---

## 💬 Notes for Reviewer

<!-- 리뷰어가 확인했으면 하는 포인트, 의문점, 논의할 사항 등을 자유롭게 작성해주세요 -->
- 논의할 사항 등을 자유롭게 작성해주세요.

---

## 📷 Screenshot / Demo
![pc](https://example.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Standardized containers to use minimum viewport height for better scrolling on: Home (Memoir Hot), Questions, My Page (Comments, Likes, Memoirs, Scrap, Temp Saved, Profile Modify), Schedule, and Onboarding.
  - Refined vertical spacing: replaced top-only margins with balanced vertical margins on My Page lists; added bottom margin to MemoirList; shifted Onboarding footer spacing from padding to margin.
  - Updated Header to display a bottom border only for a cleaner separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->