### PR TITLE
[✨ design] 0.1차 QA 반영 (#64)

### DIFF
--- a/src/app/(root)/community/page.tsx
+++ b/src/app/(root)/community/page.tsx
@@ -13,7 +13,7 @@ export default function CommunityPage() {
   return (
     <main className="flex h-screen flex-col">
       <Header title="커뮤니티" showBackButton={false} />
-      <div className="px-5 pt-6 pb-4">
+      <div className="pt-6 pb-4">
         <HotMemoirList />
       </div>
     </main>

--- a/src/app/(root)/home/components/HotMemoirList.tsx
+++ b/src/app/(root)/home/components/HotMemoirList.tsx
@@ -20,7 +20,7 @@ export default function HotMemoirList() {
 
   return (
     <section className="flex flex-col gap-4">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between px-5">
         <div className="flex items-center gap-2">
           <h3 className="typo-subhead-03 text-foundation-primary">
             이번주 HOT 회고
@@ -34,7 +34,12 @@ export default function HotMemoirList() {
         </Link>
       </div>
       <div>
-        <Swiper slidesPerView={'auto'} spaceBetween={12}>
+        <Swiper
+          slidesPerView={'auto'}
+          spaceBetween={12}
+          slidesOffsetBefore={20}
+          slidesOffsetAfter={20}
+        >
           {topMemoirs.map(memoir => (
             <SwiperSlide key={memoir.id} style={{ width: '80%' }}>
               <HotMemoirItem memoir={memoir} />

--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -8,7 +8,8 @@ interface Props {
   onClick: () => void;
 }
 
-const baseStyles = 'rounded-full cursor-pointer px-4 py-1 typo-subhead-02';
+const baseStyles =
+  'rounded-full cursor-pointer px-4 py-1 whitespace-nowrap typo-subhead-02';
 
 const variantStyle = {
   default: 'bg-foundation-box border border-foundation-secondary',

--- a/src/components/ui/SortDropdown.tsx
+++ b/src/components/ui/SortDropdown.tsx
@@ -61,7 +61,7 @@ export function SortDropdown<T extends string>({
   return (
     <div className="relative z-20" ref={dropdownRef}>
       <div
-        className="flex cursor-pointer items-center gap-1"
+        className="flex cursor-pointer items-center gap-1 whitespace-nowrap"
         onClick={() => setIsOpen(!isOpen)}
       >
         <span className="text-foundation-primary typo-subhead-02">


### PR DESCRIPTION
## 🔗 Related Issue

- close #64
- ref #64

---

## ✨ What’s this PR?

<!-- 어떤 기능/수정인지 간단히 설명해주세요 -->
임시 배포된 것을 통해 0.1차 QA를 했어요.

---

## ✅ Done

- [x] 화면이 작아질 경우 `Chip` 밸류가 줄바꿈이 발생하는 문제를 해결했어요.
- [x] Swiper에서 전체를 감싸는 x축 패딩값을 제거하고 before, after offset을 추가했어요.

---

## 💬 Notes for Reviewer

<!-- 리뷰어가 확인했으면 하는 포인트, 의문점, 논의할 사항 등을 자유롭게 작성해주세요 -->
- 논의할 사항 등을 자유롭게 작성해주세요.

---

## 📷 Screenshot / Demo
![pc](https://example.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Community page: Removed horizontal padding to provide wider content area.
  * Home – Hot Memoir List: Added header padding and improved carousel spacing with edge offsets for smoother scrolling and better item visibility.
  * Chip component: Text is now non-wrapping to keep chips on a single line and prevent layout shifts.
  * Sort Dropdown: Header label and icon no longer wrap, maintaining a consistent clickable area and cleaner alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->