### PR TITLE
[✨ feat] 커뮤니티 페이지 퍼블리싱 (#66)

### DIFF
--- a/src/app/(fullscreen)/community/job-filter/components/JobFilterView.tsx
+++ b/src/app/(fullscreen)/community/job-filter/components/JobFilterView.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { ToggleGroup } from '@/components/ui/ToggleGroup';
+import { Header } from '@/components/ui/Header';
+import { Button } from '@/components/ui/Button';
+import { POSITION } from '@/constants/code';
+import { PATH } from '@/constants/path';
+import { getPositionLabel } from '@/utils/labelUtils';
+import type { Position } from '@/types/memoirTypes';
+import XIcon from '@/assets/icon/x_icon.svg';
+import RotateIcon from '@/assets/icon/rotate_icon.svg';
+
+export default function JobFilterView() {
+  const [selectedValue, setSelectedValue] = useState('');
+  const router = useRouter();
+
+  const positionOptions = Object.values(POSITION).map(code => ({
+    id: code,
+    text: getPositionLabel(code as Position),
+  }));
+
+  const handleReset = () => {
+    setSelectedValue('');
+  };
+
+  const handleClose = () => {
+    router.push(PATH.COMMUNITY.MAIN.path);
+  };
+
+  const handleApplyFilter = () => {
+    if (selectedValue) {
+      router.push(`${PATH.COMMUNITY.MAIN.path}?position=${selectedValue}`);
+    }
+  };
+
+  return (
+    <main className="flex h-screen flex-col">
+      <Header
+        title="직무필터"
+        leftContent={<RotateIcon />}
+        rightContent={<XIcon />}
+        onBackClick={handleReset}
+        onRightClick={handleClose}
+      />
+      <div className="no-scrollbar flex-1 overflow-y-auto px-5 pt-6 pb-6">
+        <ToggleGroup
+          options={positionOptions}
+          selectedValue={selectedValue}
+          onSelectionChange={setSelectedValue}
+          className="grid w-full grid-cols-2 gap-x-4 gap-y-5"
+        />
+      </div>
+
+      <footer className="px-5 pt-4 pb-6">
+        <Button
+          size="large"
+          disabled={!selectedValue}
+          onClick={handleApplyFilter}
+        >
+          적용하기
+        </Button>
+      </footer>
+    </main>
+  );
+}

--- a/src/app/(fullscreen)/community/job-filter/page.tsx
+++ b/src/app/(fullscreen)/community/job-filter/page.tsx
@@ -1,0 +1,5 @@
+import JobFilterView from './components/JobFilterView';
+
+export default function JobFilterPage() {
+  return <JobFilterView />;
+}

--- a/src/app/(root)/community/components/FeedList.tsx
+++ b/src/app/(root)/community/components/FeedList.tsx
@@ -2,11 +2,14 @@
 
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
 
+import RotateIcon from '@/assets/icon/rotate_icon.svg';
 import FilterIcon from '@/assets/icon/filter_icon.svg';
 import { mockMemoirs } from '@/app/(fullscreen)/my-page/mocks/memoir';
 import { SortDropdown } from '@/components/ui/SortDropdown';
 import { Badge } from '@/components/ui/Badge';
+import { Chip } from '@/components/ui/Chip';
 import { cn } from '@/utils/cn';
 import { formatTimeAgo } from '@/utils/date';
 import {
@@ -14,6 +17,7 @@ import {
   getMemoirTypeLabel,
   getPositionLabel,
 } from '@/utils/labelUtils';
+import { PATH } from '@/constants/path';
 import { INTERVIEW_STATUS, MEMOIR_TYPES } from '@/constants/code';
 import type {
   InterviewStatus,
@@ -21,7 +25,6 @@ import type {
   MemoirType,
   Position,
 } from '@/types/memoirTypes';
-import { PATH } from '@/constants/path';
 
 type SortType = 'latest' | 'popularity';
 
@@ -34,20 +37,34 @@ export default function FeedList() {
   const [selectedSort, setSelectedSort] = useState<SortType>('latest');
   const [isSortPopoverOpen, setIsSortPopoverOpen] = useState(false);
 
-  const sortedMemoirs = useMemo(() => {
-    const sorted = [...mockMemoirs];
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const positionFilter = searchParams.get('position');
+
+  const filteredAndSortedMemoirs = useMemo(() => {
+    let filtered = mockMemoirs;
+    if (positionFilter) {
+      filtered = mockMemoirs.filter(
+        memoir => memoir.position === positionFilter,
+      );
+    }
+
+    const sorted = [...filtered];
     switch (selectedSort) {
       case 'latest':
         return sorted.sort(
           (a, b) =>
             new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
         );
-      //   case 'popularity':
-      //     return sorted.sort((a, b) => (b.viewCount || 0) - (a.viewCount || 0));
+      // 다른 옵션일 경우 추가 가능
       default:
         return sorted;
     }
-  }, [selectedSort]);
+  }, [selectedSort, positionFilter]);
+
+  const handleResetFilter = () => {
+    router.push(PATH.COMMUNITY.MAIN.path);
+  };
 
   const handleOverlayClick = () => {
     setIsSortPopoverOpen(false);
@@ -65,7 +82,7 @@ export default function FeedList() {
         <div className="flex items-center gap-1">
           <h3 className="typo-body-02 text-white">피드</h3>
           <span className="text-foundation-disabled typo-subhead-02">
-            {sortedMemoirs.length}
+            {filteredAndSortedMemoirs.length}
           </span>
         </div>
         <SortDropdown
@@ -77,9 +94,27 @@ export default function FeedList() {
           dropdownClassName="-translate-x-4"
         />
       </header>
-      <div className="px-5 py-4">
+      <div
+        className={cn(
+          'flex items-center px-5 py-4',
+          positionFilter ? 'justify-between' : 'justify-end',
+        )}
+      >
+        {positionFilter && (
+          <div
+            className="flex cursor-pointer items-center gap-2"
+            onClick={handleResetFilter}
+          >
+            <RotateIcon />
+            <Chip
+              text={getPositionLabel(positionFilter as Position)}
+              isSelected={true}
+              onClick={handleResetFilter}
+            />
+          </div>
+        )}
         <Link href={PATH.COMMUNITY.JOB_FILTER.path}>
-          <div className="flex items-center justify-end gap-1">
+          <div className="flex items-center gap-1">
             <FilterIcon />
             <span className="typo-subhead-02 text-foundation-primary">
               {PATH.COMMUNITY.JOB_FILTER.label}
@@ -87,7 +122,7 @@ export default function FeedList() {
           </div>
         </Link>
       </div>
-      {sortedMemoirs.map((memoir, index) => (
+      {filteredAndSortedMemoirs.map((memoir, index) => (
         <FeedItem key={memoir.id} memoir={memoir} isFirst={index === 0} />
       ))}
     </div>

--- a/src/app/(root)/community/components/FeedList.tsx
+++ b/src/app/(root)/community/components/FeedList.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+
+import FilterIcon from '@/assets/icon/filter_icon.svg';
+import { mockMemoirs } from '@/app/(fullscreen)/my-page/mocks/memoir';
+import { SortDropdown } from '@/components/ui/SortDropdown';
+import { Badge } from '@/components/ui/Badge';
+import { cn } from '@/utils/cn';
+import { formatTimeAgo } from '@/utils/date';
+import {
+  getInterviewStatusLabel,
+  getMemoirTypeLabel,
+  getPositionLabel,
+} from '@/utils/labelUtils';
+import { INTERVIEW_STATUS, MEMOIR_TYPES } from '@/constants/code';
+import type {
+  InterviewStatus,
+  Memoir,
+  MemoirType,
+  Position,
+} from '@/types/memoirTypes';
+import { PATH } from '@/constants/path';
+
+type SortType = 'latest' | 'popularity';
+
+const sortOptions: { label: string; value: SortType }[] = [
+  { label: '최신순', value: 'latest' },
+  { label: '인기순', value: 'popularity' },
+];
+
+export default function FeedList() {
+  const [selectedSort, setSelectedSort] = useState<SortType>('latest');
+  const [isSortPopoverOpen, setIsSortPopoverOpen] = useState(false);
+
+  const sortedMemoirs = useMemo(() => {
+    const sorted = [...mockMemoirs];
+    switch (selectedSort) {
+      case 'latest':
+        return sorted.sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        );
+      //   case 'popularity':
+      //     return sorted.sort((a, b) => (b.viewCount || 0) - (a.viewCount || 0));
+      default:
+        return sorted;
+    }
+  }, [selectedSort]);
+
+  const handleOverlayClick = () => {
+    setIsSortPopoverOpen(false);
+  };
+
+  return (
+    <div className="relative">
+      {isSortPopoverOpen && (
+        <div
+          onClick={handleOverlayClick}
+          className="fixed top-0 right-0 bottom-0 left-0 z-10 bg-black/50 transition-opacity duration-200"
+        />
+      )}
+      <header className="border-foundation-box flex items-center justify-between border-t-[3px] border-b px-5 py-4">
+        <div className="flex items-center gap-1">
+          <h3 className="typo-body-02 text-white">피드</h3>
+          <span className="text-foundation-disabled typo-subhead-02">
+            {sortedMemoirs.length}
+          </span>
+        </div>
+        <SortDropdown
+          options={sortOptions}
+          value={selectedSort}
+          onValueChange={setSelectedSort}
+          isOpen={isSortPopoverOpen}
+          setIsOpen={setIsSortPopoverOpen}
+          dropdownClassName="-translate-x-4"
+        />
+      </header>
+      <div className="px-5 py-4">
+        <Link href={PATH.COMMUNITY.JOB_FILTER.path}>
+          <div className="flex items-center justify-end gap-1">
+            <FilterIcon />
+            <span className="typo-subhead-02 text-foundation-primary">
+              {PATH.COMMUNITY.JOB_FILTER.label}
+            </span>
+          </div>
+        </Link>
+      </div>
+      {sortedMemoirs.map((memoir, index) => (
+        <FeedItem key={memoir.id} memoir={memoir} isFirst={index === 0} />
+      ))}
+    </div>
+  );
+}
+
+function FeedItem({ memoir, isFirst }: { memoir: Memoir; isFirst: boolean }) {
+  const interviewTypeClassName =
+    memoir.type === MEMOIR_TYPES.QUICK
+      ? 'text-secondary-btn'
+      : 'text-foundation-primary';
+  const interviewStatusClassName =
+    memoir.interviewStatus === INTERVIEW_STATUS.PASS
+      ? 'text-primary-btn'
+      : memoir.interviewStatus === INTERVIEW_STATUS.PENDING
+        ? 'text-foundation-secondary'
+        : 'text-warning';
+
+  const detailPath = PATH.MEMOIR.DETAIL.path.replace('[id]', String(memoir.id));
+
+  return (
+    <Link href={detailPath}>
+      <div
+        className={cn(
+          'border-foundation-box border-b px-5 pb-4',
+          isFirst ? 'pt-0' : 'pt-4',
+        )}
+      >
+        <div className="mb-1 flex items-center">
+          {memoir.interviewStatus && (
+            <Badge
+              size="xsmall"
+              shape="minimal"
+              className={cn('mr-2', interviewStatusClassName)}
+            >
+              {getInterviewStatusLabel(
+                memoir.interviewStatus as InterviewStatus,
+              )}
+            </Badge>
+          )}
+          <Badge
+            size="xsmall"
+            shape="minimal"
+            className={interviewTypeClassName}
+          >
+            {getMemoirTypeLabel(memoir.type as MemoirType)}
+          </Badge>
+        </div>
+
+        <div className="typo-subhead-long-03 mb-1 flex items-center gap-2">
+          <span className="text-foundation-primary">{memoir.companyName}</span>
+          <span className="text-foundation-disabled">|</span>
+          <span className="text-foundation-primary">
+            {getPositionLabel(memoir.position as Position)}
+          </span>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div className="typo-caption flex items-center gap-1">
+            <span className="text-foundation-primary">Q.</span>
+            <span className="text-foundation-secondary truncate">
+              {memoir.firstQuestion}
+            </span>
+          </div>
+
+          <span className="text-foundation-disabled typo-caption">
+            {formatTimeAgo(memoir.createdAt)}
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/app/(root)/community/components/FeedListSkeleton.tsx
+++ b/src/app/(root)/community/components/FeedListSkeleton.tsx
@@ -1,0 +1,26 @@
+export default function FeedListSkeleton() {
+  return (
+    <div className="relative animate-pulse">
+      <header className="flex items-center justify-between border-t-[3px] border-b border-gray-800/70 px-5 py-4">
+        <div className="flex items-center gap-1">
+          <div className="h-5 w-8 rounded bg-gray-800/70"></div>
+          <div className="h-5 w-8 rounded bg-gray-800/70"></div>
+        </div>
+        <div className="h-6 w-20 rounded bg-gray-800/70"></div>
+      </header>
+      <div className="flex items-center justify-end px-5 py-4">
+        <div className="h-6 w-24 rounded bg-gray-800/70"></div>
+      </div>
+      <div className="border-b border-gray-800/70 px-5 py-4">
+        <div className="mb-2 h-4 w-24 rounded bg-gray-800/70"></div>
+        <div className="mb-2 h-5 w-3/4 rounded bg-gray-800/70"></div>
+        <div className="h-4 w-full rounded bg-gray-800/70"></div>
+      </div>
+      <div className="border-b border-gray-800/70 px-5 py-4">
+        <div className="mb-2 h-4 w-24 rounded bg-gray-800/70"></div>
+        <div className="mb-2 h-5 w-3/4 rounded bg-gray-800/70"></div>
+        <div className="h-4 w-full rounded bg-gray-800/70"></div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(root)/community/page.tsx
+++ b/src/app/(root)/community/page.tsx
@@ -1,10 +1,10 @@
 import { Metadata } from 'next';
+import { Suspense } from 'react';
 
 import { Header } from '@/components/ui/Header';
 
 import HotMemoirList from '../home/components/HotMemoirList';
 import FeedList from './components/FeedList';
-import { Suspense } from 'react';
 import FeedListSkeleton from './components/FeedListSkeleton';
 
 export const metadata: Metadata = {

--- a/src/app/(root)/community/page.tsx
+++ b/src/app/(root)/community/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next';
 import { Header } from '@/components/ui/Header';
 
 import HotMemoirList from '../home/components/HotMemoirList';
+import FeedList from './components/FeedList';
 
 export const metadata: Metadata = {
   title: '커뮤니티',
@@ -11,10 +12,13 @@ export const metadata: Metadata = {
 
 export default function CommunityPage() {
   return (
-    <main className="flex h-screen flex-col">
+    <main>
       <Header title="커뮤니티" showBackButton={false} />
-      <div className="pt-6 pb-4">
+      <div className="pt-6 pb-8">
         <HotMemoirList isFullWidth={false} />
+      </div>
+      <div>
+        <FeedList />
       </div>
     </main>
   );

--- a/src/app/(root)/community/page.tsx
+++ b/src/app/(root)/community/page.tsx
@@ -4,6 +4,8 @@ import { Header } from '@/components/ui/Header';
 
 import HotMemoirList from '../home/components/HotMemoirList';
 import FeedList from './components/FeedList';
+import { Suspense } from 'react';
+import FeedListSkeleton from './components/FeedListSkeleton';
 
 export const metadata: Metadata = {
   title: '커뮤니티',
@@ -17,9 +19,9 @@ export default function CommunityPage() {
       <div className="pt-6 pb-8">
         <HotMemoirList isFullWidth={false} />
       </div>
-      <div>
+      <Suspense fallback={<FeedListSkeleton />}>
         <FeedList />
-      </div>
+      </Suspense>
     </main>
   );
 }

--- a/src/app/(root)/community/page.tsx
+++ b/src/app/(root)/community/page.tsx
@@ -14,7 +14,7 @@ export default function CommunityPage() {
     <main className="flex h-screen flex-col">
       <Header title="커뮤니티" showBackButton={false} />
       <div className="pt-6 pb-4">
-        <HotMemoirList />
+        <HotMemoirList isFullWidth={false} />
       </div>
     </main>
   );

--- a/src/app/(root)/home/components/HotMemoirList.tsx
+++ b/src/app/(root)/home/components/HotMemoirList.tsx
@@ -8,18 +8,23 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import Logo from '@/assets/logo/logo_icon.svg';
 import { Badge } from '@/components/ui/Badge';
 import { calculateDaysAgo } from '@/utils/date';
+import { cn } from '@/utils/cn';
 import { PATH } from '@/constants/path';
 import type { HotMemoir } from '@/types/memoirTypes';
 
 import { mockHotMemoirs } from '../mocks/mockHotMemoirs';
 
-export default function HotMemoirList() {
+interface Props {
+  isFullWidth?: boolean;
+}
+
+export default function HotMemoirList({ isFullWidth = true }: Props) {
   const topMemoirs = [...mockHotMemoirs].sort(
     (a, b) => b.weeklyViewCount - a.weeklyViewCount,
   );
 
   return (
-    <section className="flex flex-col gap-4">
+    <section className={cn('flex flex-col gap-4', isFullWidth && '-mx-5')}>
       <div className="flex items-center justify-between px-5">
         <div className="flex items-center gap-2">
           <h3 className="typo-subhead-03 text-foundation-primary">

--- a/src/assets/icon/filter_icon.svg
+++ b/src/assets/icon/filter_icon.svg
@@ -1,0 +1,8 @@
+<svg width="15" height="16" viewBox="0 0 15 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 2H14" stroke="#CCCCCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1 8H14" stroke="#CCCCCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1 14H14" stroke="#CCCCCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 2H4.01" stroke="#CCCCCC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 8H8.01" stroke="#CCCCCC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 14H12.01" stroke="#CCCCCC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icon/rotate_icon.svg
+++ b/src/assets/icon/rotate_icon.svg
@@ -1,0 +1,11 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1637_1237)">
+<path d="M23 4V10H17" stroke="#CCCCCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M20.4899 15C19.8399 16.8399 18.6094 18.4187 16.984 19.4985C15.3586 20.5783 13.4263 21.1006 11.4783 20.9866C9.53026 20.8726 7.67203 20.1286 6.18363 18.8667C4.69524 17.6047 3.6573 15.8932 3.22625 13.9901C2.79519 12.0869 2.99436 10.0952 3.79374 8.31508C4.59313 6.53496 5.94942 5.06288 7.65823 4.12065C9.36705 3.17843 11.3358 2.81711 13.2678 3.09116C15.1999 3.3652 16.9905 4.25975 18.3699 5.64001L22.9999 10" stroke="#CCCCCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_1637_1237">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/icon/x_icon.svg
+++ b/src/assets/icon/x_icon.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 6L6 18" stroke="#666666" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 6L18 18" stroke="#666666" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/layout/NavigationBar.tsx
+++ b/src/components/layout/NavigationBar.tsx
@@ -18,8 +18,8 @@ const navItems = [
     icon: CalendarIcon,
   },
   {
-    label: PATH.COMMUNITY.label,
-    href: PATH.COMMUNITY.path,
+    label: PATH.COMMUNITY.MAIN.label,
+    href: PATH.COMMUNITY.MAIN.path,
     icon: CommunityIcon,
   },
   { label: PATH.MY.label, href: PATH.MY.path, icon: UserIcon },

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/utils/cn';
 
 interface Props {
   title: ReactNode;
+  leftContent?: ReactNode;
   rightContent?: ReactNode | string;
   onBackClick?: () => void;
   onRightClick?: () => void;
@@ -15,6 +16,7 @@ interface Props {
 
 function Header({
   title,
+  leftContent,
   rightContent,
   onBackClick,
   onRightClick,
@@ -36,12 +38,12 @@ function Header({
       )}
     >
       {showBackButton && (
-        <div className="w-8 shrink-0">
-          <LeftArrowIcon
-            className="shrink-0 cursor-pointer"
-            aria-label="뒤로 가기"
-            onClick={handleBackClick}
-          />
+        <div
+          className="w-8 shrink-0 cursor-pointer"
+          aria-label="뒤로 가기 또는 이전 동작"
+          onClick={handleBackClick}
+        >
+          {leftContent ? leftContent : <LeftArrowIcon className="shrink-0" />}
         </div>
       )}
 

--- a/src/components/ui/SortDropdown.tsx
+++ b/src/components/ui/SortDropdown.tsx
@@ -16,6 +16,7 @@ interface Props<T extends string> {
   onValueChange: (value: T) => void;
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
+  dropdownClassName?: string;
 }
 
 const useOnClickOutside = (
@@ -45,6 +46,7 @@ export function SortDropdown<T extends string>({
   onValueChange,
   isOpen,
   setIsOpen,
+  dropdownClassName,
 }: Props<T>) {
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -74,6 +76,7 @@ export function SortDropdown<T extends string>({
         className={cn(
           'bg-foundation-box absolute top-full left-0 z-10 mt-3 w-max rounded-xl px-4 py-3',
           'transition-all duration-200 ease-in-out',
+          dropdownClassName,
           isOpen
             ? 'visible scale-100 opacity-100'
             : 'invisible scale-95 opacity-0',

--- a/src/components/ui/ToggleGroup.tsx
+++ b/src/components/ui/ToggleGroup.tsx
@@ -9,6 +9,7 @@ interface ToggleItemProps {
   text: string;
   isSelected?: boolean;
   onClick?: () => void;
+  className?: string;
 }
 
 interface ToggleGroupProps {
@@ -16,6 +17,7 @@ interface ToggleGroupProps {
   selectedValue: string;
   onSelectionChange: (value: string) => void;
   className?: string;
+  itemClassName?: string;
 }
 
 function ToggleGroup({
@@ -23,6 +25,7 @@ function ToggleGroup({
   selectedValue,
   onSelectionChange,
   className,
+  itemClassName,
 }: ToggleGroupProps) {
   return (
     <div role="radiogroup" className={cn('flex gap-2', className)}>
@@ -32,13 +35,14 @@ function ToggleGroup({
           text={option.text}
           isSelected={selectedValue === option.id}
           onClick={() => onSelectionChange(option.id)}
+          className={itemClassName}
         />
       ))}
     </div>
   );
 }
 
-function ToggleItem({ text, isSelected, onClick }: ToggleItemProps) {
+function ToggleItem({ text, isSelected, onClick, className }: ToggleItemProps) {
   return (
     <button
       role="radio"
@@ -50,6 +54,7 @@ function ToggleItem({ text, isSelected, onClick }: ToggleItemProps) {
         isSelected
           ? 'text-foundation-strong border-foundation-primary border font-bold'
           : 'text-foundation-disabled',
+        className,
       )}
     >
       {text}

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -1,6 +1,5 @@
 export const PATH = {
   HOME: { path: '/home', label: '홈' },
-  COMMUNITY: { path: '/community', label: '커뮤니티' },
   MY: { path: '/my-page', label: 'MY' },
   ALARM: { path: '/home/alarms', label: '알림' },
 
@@ -14,6 +13,11 @@ export const PATH = {
 
   INTERVIEW: {
     SCHEDULE: { path: '/home/interview/schedule', label: '면접 일정 등록' },
+  },
+
+  COMMUNITY: {
+    MAIN: { path: '/community', label: '커뮤니티' },
+    JOB_FILTER: { path: '/community/job-filter', label: '직무필터' },
   },
 
   MEMOIR: {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -117,3 +117,34 @@ export const calculateDaysAgo = (dateString: string) => {
 export const formatDateToYYMMDD = (dateString: string) => {
   return dateString.substring(2).replace(/-/g, '.');
 };
+
+/**
+ * 주어진 날짜가 현재로부터 얼마나 지났는지에 따라 "방금 전", "N분 전", "N시간 전", "N일 전" 등으로 변환합니다.
+ * @param dateString - ISO 형식의 날짜 문자열
+ * @returns "방금 전", "N분 전", "N시간 전", "N일 전" 형태의 문자열
+ */
+export const formatTimeAgo = (dateString: string): string => {
+  const now = new Date();
+  const pastDate = new Date(dateString);
+  const diffInMs = now.getTime() - pastDate.getTime();
+
+  if (diffInMs < 0) {
+    return '방금 전';
+  }
+
+  const diffInSeconds = Math.floor(diffInMs / 1000);
+  const diffInMinutes = Math.floor(diffInSeconds / 60);
+  const diffInHours = Math.floor(diffInMinutes / 60);
+  const diffInDays = Math.floor(diffInHours / 24);
+
+  if (diffInSeconds < 60) {
+    return '방금 전';
+  }
+  if (diffInMinutes < 60) {
+    return `${diffInMinutes}분 전`;
+  }
+  if (diffInHours < 24) {
+    return `${diffInHours}시간 전`;
+  }
+  return `${diffInDays}일 전`;
+};


### PR DESCRIPTION
## 🔗 Related Issue

- close #66
- ref #66

---

## ✨ What’s this PR?

<!-- 어떤 기능/수정인지 간단히 설명해주세요 -->
커뮤니티 페이지를 퍼블리싱했어요.

---

## ✅ Done

### 커뮤니티

- [x] 직무 필터 라우터 경로 추가 및 기존 커뮤니티 path 그룹핑
- [x] 커뮤니티 페이지 하단부 `피드` 퍼블리싱  
- [x] 직무 선택 페이지 제작 및 선택 시 커뮤니티 페이지에 반영되도록 구성

### 컴포넌트

- [x] 메인 페이지에서 핫회고 스타일 수정
- [x] `Header` 컴포넌트에서 뒤로가기 버튼 뿐 아니라 다른 컨텐츠도 받을 수 있도록 수정
- [x] `SortDropdown`에서 className을 받을 수 있도록 수정
- [x] `몇일 전`, `몇분 전`, `몇시간 전`을 받도록하는 유틸함수 추가
- [x] `ToggleGroup` 컴포넌트에서 className을 받을 수 있도록 수정 

---

## 💬 Notes for Reviewer

<!-- 리뷰어가 확인했으면 하는 포인트, 의문점, 논의할 사항 등을 자유롭게 작성해주세요 -->
- 논의할 사항 등을 자유롭게 작성해주세요.

---

## 📷 Screenshot / Demo
![pc](https://example.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job Filter screen to pick a position and apply/reset filters.
  * Community feed with sorting (latest), position-based filtering, item chips/counts, and navigable posts.
  * Loading skeleton for the feed and relative “time ago” timestamps on posts.

* **Style**
  * Adjusted Community page layout and Hot Memoir list width/spacing.
  * Added options for customizing dropdown and toggle item styling.

* **Refactor**
  * Reorganized Community routes and updated navigation to use the main Community path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->