### PR TITLE
[✨ feat] accessToken 만료 시 refreshToken 발급 (#74)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -34,6 +34,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: '**.kakaocdn.net',
       },
+      {
+        protocol: 'https',
+        hostname: 'devseedstorage.s3.ap-northeast-2.amazonaws.com',
+      },
     ],
   },
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -40,6 +40,14 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${process.env.NEXT_PUBLIC_DEVSEED_BASE_URL}/api/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/apis/memoirApi.ts
+++ b/src/apis/memoirApi.ts
@@ -57,7 +57,7 @@ export const getMemoirDetails = async (
 ): Promise<ApiResponse<MemoirData>> => {
   const response = await http.get(`/memoirs/${memoirId}`, {
     headers: {
-      Cookie: cookie || '',
+      Cookie: cookie,
     },
   });
 

--- a/src/apis/memoirApi.ts
+++ b/src/apis/memoirApi.ts
@@ -6,6 +6,7 @@ import type {
   Memoir,
   MemoirData,
   MemoirsRequest,
+  PaginatedCommentList,
   PaginatedMemoirData,
   PaginatedMemoirListData,
 } from '@/types/memoirTypes';
@@ -163,10 +164,21 @@ export const toggleLikeMemoir = async (
 };
 
 // 댓글 목록 조회 API
-export const getMemoirComments = async (
-  memoirId: number,
-): Promise<ApiResponse<Comment[]>> => {
-  const response = await http.get(`/memoirs/${memoirId}/comments`);
+export const getMemoirComments = async ({
+  memoirId,
+  cursor,
+  size,
+}: {
+  memoirId: number;
+  cursor?: string | null;
+  size?: number;
+}): Promise<ApiResponse<PaginatedCommentList>> => {
+  const response = await http.get(`/memoirs/${memoirId}/comments`, {
+    params: {
+      cursor,
+      size,
+    },
+  });
 
   return response.data;
 };
@@ -180,7 +192,7 @@ export const createMemoirComment = async ({
   memoirId: number;
   content: string;
   parentCommentId?: number;
-}): Promise<ApiResponse<Comment>> => {
+}): Promise<ApiResponse<void>> => {
   const response = await http.post(`/memoirs/${memoirId}/comments`, {
     content,
     parentCommentId,

--- a/src/app/(fullscreen)/home/alarms/components/AlarmList.tsx
+++ b/src/app/(fullscreen)/home/alarms/components/AlarmList.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { alarmQueries } from '@/queries/alarmOptions';
+import { Badge } from '@/components/ui/Badge';
+import { EmptyState } from '@/components/ui/Empty';
+import { formatTimeAgo } from '@/utils/date';
+import type { Alarm } from '@/types/alarmTypes';
+
+export default function AlarmList() {
+  const { data, isPending } = useQuery(alarmQueries.list());
+
+  const alarms = data?.data || [];
+
+  return (
+    <section className="flex flex-1 flex-col">
+      {isPending ? (
+        <div className="flex flex-col gap-4 p-5">
+          {Array.from({ length: 3 }, (_, index) => (
+            <AlarmItemSkeleton key={index} />
+          ))}
+        </div>
+      ) : alarms.length > 0 ? (
+        alarms.map((alarm, index) => <AlarmItem key={index} alarm={alarm} />)
+      ) : (
+        <EmptyState text="아직 도착한 알림이 없어요." />
+      )}
+    </section>
+  );
+}
+
+function AlarmItem({ alarm }: { alarm: Alarm }) {
+  return (
+    <div className="border-foundation-box border-b p-5">
+      <Badge size="xsmall" shape="minimal" className="text-foundation-primary">
+        {alarm.notificationCategory}
+      </Badge>
+      <p className="typo-subhead-02 text-foundation-primary mt-2 mb-1">
+        {alarm.content}
+      </p>
+      <span className="text-foundation-secondary typo-body-long-01">
+        {formatTimeAgo(alarm.createdAt)}
+      </span>
+    </div>
+  );
+}
+
+function AlarmItemSkeleton() {
+  return (
+    <div className="border-foundation-box bg-foundation-box animate-pulse rounded border-b p-5">
+      <div className="bg-foundation-bg mb-2 h-5 w-20 rounded-md" />
+      <div className="bg-foundation-bg mb-1.5 h-5 w-full rounded-md" />
+      <div className="bg-foundation-bg h-4 w-1/4 rounded-md" />
+    </div>
+  );
+}

--- a/src/app/(fullscreen)/home/alarms/page.tsx
+++ b/src/app/(fullscreen)/home/alarms/page.tsx
@@ -2,6 +2,8 @@ import { Metadata } from 'next';
 
 import { Header } from '@/components/ui/Header';
 
+import AlarmList from './components/AlarmList';
+
 export const metadata: Metadata = {
   title: '알림',
   description: '면접 일정에 대한 알림을 확인하고 관리해보세요.',
@@ -9,8 +11,9 @@ export const metadata: Metadata = {
 
 export default function AlarmsPage() {
   return (
-    <>
-      <Header title="알림" />
-    </>
+    <main className="flex min-h-dvh flex-col">
+      <Header title="알람" />
+      <AlarmList />
+    </main>
   );
 }

--- a/src/app/(fullscreen)/home/memoir/[slug]/components/CommentDrawer.tsx
+++ b/src/app/(fullscreen)/home/memoir/[slug]/components/CommentDrawer.tsx
@@ -1,0 +1,142 @@
+import { useState, useMemo, useRef, useCallback } from 'react';
+
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+import {
+  BottomDrawer,
+  BottomDrawerContent,
+  BottomDrawerFooter,
+  BottomDrawerHandle,
+  BottomDrawerHeader,
+} from '@/components/ui/Drawer';
+import {
+  memoirInfiniteQueries,
+  memoirMutations,
+} from '@/queries/memoirOptions';
+
+import CommentList from './CommentList';
+import CommentInput from './CommentInput';
+
+interface Props {
+  memoirId: number;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function CommentDrawer({ memoirId, isOpen, onClose }: Props) {
+  const queryClient = useQueryClient();
+  const [newComment, setNewComment] = useState('');
+  const [replyToCommentId, setReplyToCommentId] = useState<number | null>(null);
+  const [replyToAuthor, setReplyToAuthor] = useState<string | null>(null);
+
+  const {
+    data: commentsData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isPending,
+    isError,
+  } = useInfiniteQuery({
+    ...memoirInfiniteQueries.comments(memoirId),
+    enabled: isOpen,
+  });
+
+  const allComments = useMemo(() => {
+    const flatComments =
+      commentsData?.pages.flatMap(page => page.data.result) || [];
+
+    const uniqueComments = Array.from(
+      new Map(flatComments.map(comment => [comment.id, comment])).values(),
+    );
+
+    return uniqueComments;
+  }, [commentsData]);
+
+  const observer = useRef<IntersectionObserver | null>(null);
+  const lastCommentRef = useCallback(
+    (node: HTMLDivElement) => {
+      if (isFetchingNextPage) return;
+      if (observer.current) observer.current.disconnect();
+
+      observer.current = new IntersectionObserver(entries => {
+        if (entries[0].isIntersecting && hasNextPage) {
+          fetchNextPage();
+        }
+      });
+
+      if (node) observer.current.observe(node);
+    },
+    [isFetchingNextPage, fetchNextPage, hasNextPage],
+  );
+
+  const { mutate: createComment, isPending: isPosting } = useMutation({
+    ...memoirMutations.createComment(queryClient),
+  });
+
+  const handleCommentSubmit = () => {
+    if (!newComment.trim() || isPosting) return;
+    createComment(
+      { memoirId, content: newComment, parentCommentId: replyToCommentId },
+      {
+        onSuccess: () => {
+          setNewComment('');
+          setReplyToCommentId(null);
+          setReplyToAuthor(null);
+        },
+        onError: () => {
+          alert('댓글 등록에 실패했습니다.');
+        },
+      },
+    );
+  };
+
+  const handleReplyClick = (commentId: number, author: string) => {
+    setReplyToCommentId(commentId);
+    setReplyToAuthor(author);
+  };
+
+  const handleCancelReply = () => {
+    setReplyToCommentId(null);
+    setReplyToAuthor(null);
+  };
+
+  const commentInputPlaceholder = replyToAuthor
+    ? `@${replyToAuthor}님에게 답글 달기...`
+    : '댓글 달기...';
+
+  return (
+    <BottomDrawer isOpen={isOpen} onOpenChange={open => !open && onClose()}>
+      <BottomDrawerHandle />
+      <BottomDrawerHeader title="댓글" onClose={onClose} />
+      <BottomDrawerContent className="overscroll-contain">
+        <CommentList
+          comments={allComments}
+          isPending={isPending}
+          isError={isError}
+          lastCommentRef={lastCommentRef}
+          onReplyClick={handleReplyClick}
+        />
+        {isFetchingNextPage && (
+          <div className="py-2 text-center text-sm text-gray-500">
+            댓글을 불러오는 중...
+          </div>
+        )}
+      </BottomDrawerContent>
+      <BottomDrawerFooter>
+        <CommentInput
+          value={newComment}
+          onChange={e => setNewComment(e.target.value)}
+          onSubmit={handleCommentSubmit}
+          isPosting={isPosting}
+          placeholder={commentInputPlaceholder}
+          isReplying={!!replyToCommentId}
+          onCancelReply={handleCancelReply}
+        />
+      </BottomDrawerFooter>
+    </BottomDrawer>
+  );
+}

--- a/src/app/(fullscreen)/home/memoir/[slug]/components/CommentInput.tsx
+++ b/src/app/(fullscreen)/home/memoir/[slug]/components/CommentInput.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { Input } from '@/components/ui/Input';
+import SendIcon from '@/assets/icon/send_icon.svg';
+
+interface Props {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onSubmit: () => void;
+  isPosting: boolean;
+  placeholder?: string;
+  isReplying?: boolean;
+  onCancelReply?: () => void;
+}
+
+export default function CommentInput({
+  value,
+  onChange,
+  onSubmit,
+  isPosting,
+  placeholder = '댓글 달기...',
+  isReplying,
+  onCancelReply,
+}: Props) {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      onSubmit();
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      {isReplying && onCancelReply && (
+        <div className="text-foundation-secondary typo-caption flex items-center justify-between px-1">
+          <span>{placeholder.split('...')[0]}</span>
+          <button onClick={onCancelReply} className="flex items-center gap-1">
+            취소
+          </button>
+        </div>
+      )}
+      <div className="relative">
+        <Input
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+          onKeyDown={handleKeyDown}
+          className="w-full"
+          disabled={isPosting}
+          icons={<SendIcon />}
+          onClear={onSubmit}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(fullscreen)/home/memoir/[slug]/components/CommentList.tsx
+++ b/src/app/(fullscreen)/home/memoir/[slug]/components/CommentList.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import Image from 'next/image';
+
+import { formatTimeAgo } from '@/utils/date';
+import type { Comment } from '@/types/memoirTypes';
+import Logo from '@/assets/logo/logo_icon.svg';
+
+interface Props {
+  comments: Comment[];
+  isPending: boolean;
+  isError: boolean;
+  lastCommentRef: (node: HTMLDivElement) => void;
+  onReplyClick: (commentId: number, author: string) => void;
+}
+
+export default function CommentList({
+  comments,
+  isPending,
+  isError,
+  lastCommentRef,
+  onReplyClick,
+}: Props) {
+  if (isPending) {
+    return (
+      <div className="flex flex-col gap-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <CommentSkeleton key={i} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <div className="py-10 text-center">댓글을 불러오지 못했습니다.</div>;
+  }
+
+  if (comments.length === 0) {
+    return (
+      <div className="text-foundation-primary py-10 text-center">
+        작성된 댓글이 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-8 p-5">
+      {comments.map((comment, index) => {
+        const isLastItem = comments.length === index + 1;
+
+        return (
+          <div key={comment.id} ref={isLastItem ? lastCommentRef : null}>
+            <CommentItem comment={comment} onReplyClick={onReplyClick} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function CommentItem({
+  comment,
+  onReplyClick,
+}: {
+  comment: Comment;
+  onReplyClick: (commentId: number, author: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-start gap-3">
+        <figure className="h-10 w-10 shrink-0 rounded-full">
+          {comment.profileImageUrl ? (
+            <Image
+              src={comment.profileImageUrl}
+              alt={comment.author}
+              width={40}
+              height={40}
+              className="h-full w-full rounded-full object-cover"
+            />
+          ) : (
+            <div className="bg-foundation-secondary/20 flex h-full w-full items-center justify-center rounded-full">
+              <Logo height={20} width={20} />
+            </div>
+          )}
+        </figure>
+
+        <div className="flex flex-col">
+          <div className="flex items-center gap-2">
+            <span className="typo-subhead-02 text-foundation-strong">
+              {comment.author}
+            </span>
+            <span className="typo-caption text-foundation-disabled">
+              {formatTimeAgo(comment.createdAt)}
+            </span>
+          </div>
+          <p className="typo-subhead-02 text-foundation-primary whitespace-pre-wrap">
+            {comment.content}
+          </p>
+          {comment.isParent && (
+            <button
+              className="typo-caption text-foundation-disabled mt-px w-fit cursor-pointer"
+              onClick={() => onReplyClick(comment.id, comment.author)}
+            >
+              답글달기
+            </button>
+          )}
+        </div>
+      </div>
+
+      {comment.children && comment.children.length > 0 && (
+        <div className="ml-8 flex flex-col gap-4">
+          {comment.children.map(reply => (
+            <CommentItem
+              key={reply.id}
+              comment={reply}
+              onReplyClick={onReplyClick}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function CommentSkeleton() {
+  return (
+    <div className="flex animate-pulse items-start gap-3 p-5">
+      <div className="bg-foundation-box h-8 w-8 shrink-0 rounded-full" />
+      <div className="flex w-full flex-col gap-1.5">
+        <div className="bg-foundation-box h-4 w-1/2 rounded-md" />
+        <div className="bg-foundation-box h-4 w-full rounded-md" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(fullscreen)/home/memoir/[slug]/components/MemoirDetailAction.tsx
+++ b/src/app/(fullscreen)/home/memoir/[slug]/components/MemoirDetailAction.tsx
@@ -7,9 +7,10 @@ import { cn } from '@/utils/cn';
 
 interface Props {
   isLike?: boolean;
+  onCommentClick?: () => void;
 }
 
-export default function MemoirDetailAction({ isLike }: Props) {
+export default function MemoirDetailAction({ isLike, onCommentClick }: Props) {
   return (
     <div className="border-foundation-divider flex items-center justify-between border-t p-5">
       <div className="flex items-center gap-[14px]">
@@ -24,7 +25,7 @@ export default function MemoirDetailAction({ isLike }: Props) {
         </div>
 
         <div className="flex items-center gap-1">
-          <CommentIcon className="cursor-pointer" />
+          <CommentIcon className="cursor-pointer" onClick={onCommentClick} />
           <span className="text-foundation-secondary typo-subhead-03">12</span>
         </div>
       </div>

--- a/src/app/(fullscreen)/home/memoir/[slug]/components/MemoirDetailAction.tsx
+++ b/src/app/(fullscreen)/home/memoir/[slug]/components/MemoirDetailAction.tsx
@@ -1,36 +1,79 @@
 'use client';
 
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import LikeIcon from '@/assets/icon/heart_icon.svg';
 import CommentIcon from '@/assets/icon/comment_icon.svg';
 import BookmarkIcon from '@/assets/icon/bookmark_icon.svg';
 import { cn } from '@/utils/cn';
+import { memoirMutations } from '@/queries/memoirOptions';
 
 interface Props {
-  isLike?: boolean;
+  memoirId: number;
+  likeCount: number;
+  commentCountText: string;
+  isLiked: boolean;
+  isBookmarked: boolean;
   onCommentClick?: () => void;
 }
 
-export default function MemoirDetailAction({ isLike, onCommentClick }: Props) {
+export default function MemoirDetailAction({
+  memoirId,
+  likeCount,
+  commentCountText,
+  isLiked,
+  isBookmarked,
+  onCommentClick,
+}: Props) {
+  const queryClient = useQueryClient();
+
+  const { mutate: toggleLike } = useMutation(
+    memoirMutations.toggleLike(queryClient),
+  );
+  const { mutate: toggleBookmark } = useMutation(
+    memoirMutations.toggleBookmark(queryClient),
+  );
+
+  const handleLikeClick = () => {
+    toggleLike(memoirId);
+  };
+
+  const handleBookmarkClick = () => {
+    toggleBookmark(memoirId);
+  };
+
   return (
     <div className="border-foundation-divider flex items-center justify-between border-t p-5">
       <div className="flex items-center gap-[14px]">
         <div className="flex items-center gap-1">
           <LikeIcon
+            onClick={handleLikeClick}
             className={cn(
               'cursor-pointer',
-              isLike ? 'text-warning' : 'fill-transparent text-[#888888]',
+              isLiked ? 'text-warning' : 'fill-transparent text-[#888888]',
             )}
           />
-          <span className="text-foundation-secondary typo-subhead-03">16</span>
+          <span className="text-foundation-secondary typo-subhead-03">
+            {likeCount}
+          </span>
         </div>
 
         <div className="flex items-center gap-1">
           <CommentIcon className="cursor-pointer" onClick={onCommentClick} />
-          <span className="text-foundation-secondary typo-subhead-03">12</span>
+          <span className="text-foundation-secondary typo-subhead-03">
+            {commentCountText}
+          </span>
         </div>
       </div>
 
-      <BookmarkIcon className="cursor-pointer" />
+      <BookmarkIcon
+        className={cn(
+          'cursor-pointer',
+          isBookmarked ? 'text-secondary-btn' : 'transparent border-[#888888]',
+        )}
+        fill={isBookmarked ? 'currentColor' : 'transparent'}
+        onClick={handleBookmarkClick}
+      />
     </div>
   );
 }

--- a/src/app/(fullscreen)/home/memoir/[slug]/components/MemoirDetailView.tsx
+++ b/src/app/(fullscreen)/home/memoir/[slug]/components/MemoirDetailView.tsx
@@ -22,6 +22,7 @@ import type { MemoirData } from '@/types/memoirTypes';
 
 import MemoirDetailContent from './MemoirDetailContent';
 import MemoirDetailAction from './MemoirDetailAction';
+import CommentDrawer from './CommentDrawer';
 
 interface Props {
   memoirData: MemoirData;
@@ -31,6 +32,7 @@ export default function MemoirDetailView({ memoirData }: Props) {
   const router = useRouter();
   const queryClient = useQueryClient();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [isCommentDrawerOpen, setIsCommentDrawerOpen] = useState(false);
 
   const { mutate: deleteMemoir } = useMutation(
     memoirMutations.delete(queryClient),
@@ -78,7 +80,10 @@ export default function MemoirDetailView({ memoirData }: Props) {
 
       {memoirData.isPublic && (
         <footer>
-          <MemoirDetailAction isLike={false} />
+          <MemoirDetailAction
+            isLike={false}
+            onCommentClick={() => setIsCommentDrawerOpen(true)}
+          />
         </footer>
       )}
 
@@ -124,6 +129,12 @@ export default function MemoirDetailView({ memoirData }: Props) {
           </Button>
         </BottomDrawerFooter>
       </BottomDrawer>
+
+      <CommentDrawer
+        memoirId={memoirData.id}
+        isOpen={isCommentDrawerOpen}
+        onClose={() => setIsCommentDrawerOpen(false)}
+      />
     </div>
   );
 }

--- a/src/app/(fullscreen)/home/memoir/[slug]/components/MemoirDetailView.tsx
+++ b/src/app/(fullscreen)/home/memoir/[slug]/components/MemoirDetailView.tsx
@@ -1,8 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 
 import { Header } from '@/components/ui/Header';
 import { Button } from '@/components/ui/Button';
@@ -14,7 +19,11 @@ import {
   BottomDrawerHeader,
 } from '@/components/ui/Drawer';
 import { cn } from '@/utils/cn';
-import { memoirMutations } from '@/queries/memoirOptions';
+import {
+  memoirInfiniteQueries,
+  memoirMutations,
+  memoirQueries,
+} from '@/queries/memoirOptions';
 import { MEMOIR_TYPES } from '@/constants/code';
 import { PATH } from '@/constants/path';
 import MoreIcon from '@/assets/icon/more_icon.svg';
@@ -28,15 +37,34 @@ interface Props {
   memoirData: MemoirData;
 }
 
-export default function MemoirDetailView({ memoirData }: Props) {
+export default function MemoirDetailView({ memoirData: initialData }: Props) {
   const router = useRouter();
   const queryClient = useQueryClient();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [isCommentDrawerOpen, setIsCommentDrawerOpen] = useState(false);
 
+  const { data: memoirQueryData } = useQuery({
+    ...memoirQueries.detail(initialData.id),
+    initialData: { data: initialData, code: '200', message: 'Success' },
+  });
+
+  const memoirData = memoirQueryData?.data || initialData;
+
   const { mutate: deleteMemoir } = useMutation(
     memoirMutations.delete(queryClient),
   );
+  const { data: commentsData, hasNextPage } = useInfiniteQuery({
+    ...memoirInfiniteQueries.comments(memoirData.id),
+  });
+
+  const allComments = useMemo(
+    () => commentsData?.pages.flatMap(page => page.data.result) || [],
+    [commentsData],
+  );
+
+  const commentCountText = hasNextPage
+    ? `${allComments.length}+`
+    : String(allComments.length);
 
   const handleEdit = () => {
     router.push(PATH.MEMOIR.EDIT.path.replace('[id]', String(memoirData.id)));
@@ -81,7 +109,11 @@ export default function MemoirDetailView({ memoirData }: Props) {
       {memoirData.isPublic && (
         <footer>
           <MemoirDetailAction
-            isLike={false}
+            memoirId={memoirData.id}
+            isLiked={memoirData.isLiked}
+            isBookmarked={memoirData.isBookmarked}
+            likeCount={memoirData.likeCount ?? 0}
+            commentCountText={commentCountText}
             onCommentClick={() => setIsCommentDrawerOpen(true)}
           />
         </footer>

--- a/src/app/(fullscreen)/home/memoir/general/components/GeneralMemoirView.tsx
+++ b/src/app/(fullscreen)/home/memoir/general/components/GeneralMemoirView.tsx
@@ -42,8 +42,8 @@ export default function GeneralMemoirView({
   );
   const isPending = isCreatePending || isUpdatePending;
 
-  const handleSave = () => {
-    if (!isSaveButtonEnabled) return;
+  const handleSubmit = (isDraft: boolean) => {
+    if (!isDraft && !isSaveButtonEnabled) return;
 
     const payload: Omit<MemoirsRequest, 'id'> = {
       type: MEMOIR_TYPES.GENERAL,
@@ -58,7 +58,13 @@ export default function GeneralMemoirView({
         answer: q.answer,
         order: index + 1,
       })),
-      isTmp: false,
+      isTmp: isDraft,
+    };
+
+    const handleSuccess = (message: string, redirectPath: string) => {
+      alert(message);
+      resetForm();
+      router.push(redirectPath);
     };
 
     if (mode === 'edit' && memoirId) {
@@ -66,40 +72,41 @@ export default function GeneralMemoirView({
         { ...payload, id: memoirId },
         {
           onSuccess: () => {
-            alert('회고가 성공적으로 수정되었습니다!');
-            resetForm();
-            router.push(
-              PATH.MEMOIR.DETAIL.path.replace('[id]', String(memoirId)),
-            );
+            const message = `회고가 성공적으로 ${isDraft ? '임시저장' : '수정'}되었습니다!`;
+            const path = isDraft
+              ? PATH.MY_PAGE.TEMP_SAVED.path
+              : PATH.MEMOIR.DETAIL.path.replace('[id]', String(memoirId));
+            handleSuccess(message, path);
           },
-          onError: () => {
-            alert('회고 수정에 실패했습니다. 다시 시도해주세요.');
-          },
+          onError: () =>
+            alert(`회고 ${isDraft ? '임시저장' : '수정'}에 실패했습니다.`),
         },
       );
     } else {
       createMemoir(payload, {
         onSuccess: response => {
-          const newMemoirId = response.data;
+          const newMemoirId = response.data.id;
           if (newMemoirId) {
-            alert('회고가 성공적으로 저장되었습니다!');
-            resetForm();
-            const detailPath = PATH.MEMOIR.DETAIL.path.replace(
-              '[id]',
-              String(newMemoirId),
-            );
-            router.push(detailPath);
+            const message = `회고가 성공적으로 ${isDraft ? '임시저장' : '저장'}되었습니다!`;
+            const path = isDraft
+              ? PATH.MY_PAGE.MEMOIRS.path
+              : PATH.MEMOIR.DETAIL.path.replace('[id]', String(newMemoirId));
+            handleSuccess(message, path);
           } else {
-            alert('회고가 저장되었지만, 홈으로 이동합니다.');
-            router.push(PATH.HOME.path);
+            handleSuccess(
+              '회고가 저장되었지만, 홈으로 이동합니다.',
+              PATH.HOME.path,
+            );
           }
         },
-        onError: () => {
-          alert('회고 저장에 실패했습니다. 다시 시도해주세요.');
-        },
+        onError: () =>
+          alert(`회고 ${isDraft ? '임시저장' : '저장'}에 실패했습니다.`),
       });
     }
   };
+
+  const handleSave = () => handleSubmit(false);
+  const handleSaveDraft = () => handleSubmit(true);
 
   return (
     <div className="flex h-screen flex-col">
@@ -114,7 +121,12 @@ export default function GeneralMemoirView({
 
       <footer className="px-5 pt-4 pb-6">
         <div className="flex gap-2">
-          <Button variant="outline" size="small">
+          <Button
+            variant="outline"
+            size="small"
+            onClick={handleSaveDraft}
+            disabled={isPending}
+          >
             임시저장
           </Button>
           <Button

--- a/src/app/(fullscreen)/home/memoir/general/store/generalMemoirFormStore.ts
+++ b/src/app/(fullscreen)/home/memoir/general/store/generalMemoirFormStore.ts
@@ -14,6 +14,17 @@ import type {
   MemoirData,
 } from '@/types/memoirTypes';
 import { convertISOToTimeValue } from '@/utils/date';
+import {
+  INTERVIEW_FORMAT_LABELS,
+  INTERVIEW_LEVEL_LABELS,
+  INTERVIEW_METHOD_LABELS,
+  INTERVIEW_MOOD_LABELS,
+  INTERVIEW_STATUS_LABELS,
+  INTERVIEW_STEP_LABELS,
+  POSITION_LABELS,
+  QUESTION_TYPE_LABELS,
+  SATISFACTION_NOTE_LABELS,
+} from '@/constants/labels';
 
 const initialFormData: GeneralMemoirFormData = {
   interviewInfo: {
@@ -69,6 +80,17 @@ interface ReferenceData {
   url: string;
 }
 
+const findCodeByLabel = (
+  labelsObject: Record<string, string>,
+  label: string,
+): string => {
+  if (!label) return '';
+  const entry = Object.entries(labelsObject).find(
+    ([_code, lbl]) => lbl === label,
+  );
+  return entry ? entry[0] : '';
+};
+
 export interface GeneralMemoirFormData {
   interviewInfo: InterviewInfoData;
   questions: Questions[];
@@ -105,23 +127,47 @@ export const useGeneralMemoirFormStore = create<GeneralMemoirFormState>(
             interviewDate: new Date(data.interviewDatetime),
             interviewTime:
               convertISOToTimeValue(data.interviewDatetime) ?? null,
-            position: data.position as Position,
-            interviewStep: (data.interviewStep || '') as InterviewStep,
-            interviewFormat: (data.interviewFormat || '') as InterviewFormat,
-            interviewMethod: (data.interviewMethod || '') as InterviewMethod,
-            interviewMood: (data.interviewMood || '') as InterviewMood,
+            position: findCodeByLabel(
+              POSITION_LABELS,
+              data.position,
+            ) as Position,
+            interviewStep: findCodeByLabel(
+              INTERVIEW_STEP_LABELS,
+              data.interviewStep || '',
+            ) as InterviewStep,
+            interviewFormat: findCodeByLabel(
+              INTERVIEW_FORMAT_LABELS,
+              data.interviewFormat || '',
+            ) as InterviewFormat,
+            interviewMethod: findCodeByLabel(
+              INTERVIEW_METHOD_LABELS,
+              data.interviewMethod || '',
+            ) as InterviewMethod,
+            interviewMood: findCodeByLabel(
+              INTERVIEW_MOOD_LABELS,
+              data.interviewMood || '',
+            ) as InterviewMood,
           },
           questions: data.questions.map(q => ({
             order: q.id,
-            questionType: q.questionType,
+            questionType: findCodeByLabel(QUESTION_TYPE_LABELS, q.questionType),
             title: q.title,
             answer: q.answer || '',
           })),
           interviewReview: {
-            interviewLevel: (data.interviewLevel || '') as InterviewLevel,
-            satisfactionNote: (data.satisfactionNote || '') as SatisfactionNote,
-            freeNote: (data.freeNote || '') as string,
-            interviewStatus: (data.interviewStatus || '') as InterviewStatus,
+            interviewLevel: findCodeByLabel(
+              INTERVIEW_LEVEL_LABELS,
+              data.interviewLevel || '',
+            ) as InterviewLevel,
+            satisfactionNote: findCodeByLabel(
+              SATISFACTION_NOTE_LABELS,
+              data.satisfactionNote || '',
+            ) as SatisfactionNote,
+            freeNote: data.freeNote || '',
+            interviewStatus: findCodeByLabel(
+              INTERVIEW_STATUS_LABELS,
+              data.interviewStatus || '',
+            ) as InterviewStatus,
             isPublic: data.isPublic,
           },
           references: {

--- a/src/app/(fullscreen)/home/questions/today/components/TodayQuestionDetail.tsx
+++ b/src/app/(fullscreen)/home/questions/today/components/TodayQuestionDetail.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import Link from 'next/link';
+
+import { Badge } from '@/components/ui/Badge';
+import { EmptyState } from '@/components/ui/Empty';
+import { PATH } from '@/constants/path';
+import { formatDateToYYMMDD } from '@/utils/date';
+import RightIcon from '@/assets/icon/right_arrow_icon.svg';
+
+import { useTodayQuestion } from '../hooks/useTodayQuestion';
+
+export default function TodayQuestionDetail() {
+  const { todayQuestionData, isPending, isError } = useTodayQuestion();
+
+  if (isPending) {
+    return <TodayQuestionSkeleton />;
+  }
+
+  if (isError || !todayQuestionData) {
+    return (
+      <div className="pt-10">
+        <EmptyState text="표시할 질문이 없습니다. 회고를 먼저 작성해주세요." />
+      </div>
+    );
+  }
+
+  const { memoir, question } = todayQuestionData;
+
+  return (
+    <div className="flex flex-col gap-8 p-5">
+      <section>
+        <Badge
+          shape="minimal"
+          size="xsmall"
+          className="text-foundation-primary"
+        >
+          {question.questionType}
+        </Badge>
+        <div className="mt-4 flex flex-col gap-4">
+          <p className="typo-subhead-03">
+            <span className="text-secondary-btn">Q. </span>
+            <span className="text-foundation-strong">{question.title}</span>
+          </p>
+          <p className="typo-body-long-01 text-foundation-secondary whitespace-pre-wrap">
+            A. {question.answer}
+          </p>
+        </div>
+      </section>
+
+      <section>
+        <p className="typo-subhead-03 text-foundation-primary mb-2">
+          회고 정보
+        </p>
+        <Link href={PATH.MEMOIR.DETAIL.path.replace('[id]', String(memoir.id))}>
+          <div className="bg-foundation-box flex cursor-pointer items-center justify-between rounded-xl px-5 py-3">
+            <div>
+              <p className="typo-subhead-long-03 text-foundation-primary">
+                {memoir.companyName}
+              </p>
+              <span className="typo-body-01 text-foundation-secondary">
+                회고일자 {formatDateToYYMMDD(memoir.interviewDatetime)}
+              </span>
+            </div>
+            <RightIcon className="text-foundation-secondary" />
+          </div>
+        </Link>
+      </section>
+    </div>
+  );
+}
+
+function TodayQuestionSkeleton() {
+  return (
+    <div className="animate-pulse p-5">
+      <div className="bg-foundation-box mb-4 h-6 w-24 rounded-md" />
+      <div className="mb-8 space-y-2">
+        <div className="bg-foundation-box h-6 w-full rounded-md" />
+        <div className="bg-foundation-box h-20 w-full rounded-md" />
+      </div>
+      <div className="bg-foundation-box h-20 w-full rounded-xl" />
+    </div>
+  );
+}

--- a/src/app/(fullscreen)/home/questions/today/hooks/useTodayQuestion.ts
+++ b/src/app/(fullscreen)/home/questions/today/hooks/useTodayQuestion.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { memoirQueries } from '@/queries/memoirOptions';
+
+const FEATURED_MEMOIR_ID = 20;
+
+export function useTodayQuestion() {
+  const {
+    data: memoirDetailResponse,
+    isPending,
+    isError,
+  } = useQuery(memoirQueries.detail(FEATURED_MEMOIR_ID));
+
+  const todayQuestionData = useMemo(() => {
+    const memoirDetail = memoirDetailResponse?.data;
+    if (!memoirDetail || !memoirDetail.questions?.[0]) {
+      return null;
+    }
+
+    return {
+      memoir: memoirDetail,
+      question: memoirDetail.questions[0],
+    };
+  }, [memoirDetailResponse]);
+
+  return {
+    todayQuestionData,
+    isPending,
+    isError,
+  };
+}

--- a/src/app/(fullscreen)/home/questions/today/page.tsx
+++ b/src/app/(fullscreen)/home/questions/today/page.tsx
@@ -1,0 +1,17 @@
+import { Header } from '@/components/ui/Header';
+
+import TodayQuestionDetail from './components/TodayQuestionDetail';
+
+export const metadata = {
+  title: '오늘의 질문',
+  description: '오늘의 질문에 대한 상세 정보를 확인하세요.',
+};
+
+export default function TodayQuestion() {
+  return (
+    <div>
+      <Header title="오늘의 질문" />
+      <TodayQuestionDetail />
+    </div>
+  );
+}

--- a/src/app/(fullscreen)/my-page/components/MemoirItem.tsx
+++ b/src/app/(fullscreen)/my-page/components/MemoirItem.tsx
@@ -8,13 +8,20 @@ import { PATH } from '@/constants/path';
 interface Props {
   memoir: ApiMemoirItem;
   hideBadge?: boolean;
+  hrefPattern?: string;
 }
 
-export default function MemoirItem({ memoir, hideBadge = false }: Props) {
+export default function MemoirItem({
+  memoir,
+  hideBadge = false,
+  hrefPattern,
+}: Props) {
   const badgeTextColor =
     memoir.type === '퀵 회고' ? 'text-secondary-btn' : 'text-primary-btn';
 
-  const detailPath = PATH.MEMOIR.DETAIL.path.replace('[id]', String(memoir.id));
+  const detailPath =
+    hrefPattern?.replace('[id]', String(memoir.id)) ??
+    PATH.MEMOIR.DETAIL.path.replace('[id]', String(memoir.id));
 
   return (
     <Link href={detailPath}>

--- a/src/app/(fullscreen)/my-page/components/MemoirList.tsx
+++ b/src/app/(fullscreen)/my-page/components/MemoirList.tsx
@@ -7,15 +7,26 @@ interface Props {
   memoirs: ApiMemoirItem[];
   hideBadge?: boolean;
   emptyText: string;
+  itemHrefPattern?: string;
 }
 
-export default function MemoirList({ memoirs, hideBadge, emptyText }: Props) {
+export default function MemoirList({
+  memoirs,
+  hideBadge,
+  emptyText,
+  itemHrefPattern,
+}: Props) {
   return (
     <>
       <div className="mb-5 flex flex-1 flex-col gap-3 px-5">
         {memoirs.length > 0 ? (
           memoirs.map(memoir => (
-            <MemoirItem key={memoir.id} memoir={memoir} hideBadge={hideBadge} />
+            <MemoirItem
+              key={memoir.id}
+              memoir={memoir}
+              hideBadge={hideBadge}
+              hrefPattern={itemHrefPattern}
+            />
           ))
         ) : (
           <EmptyState text={emptyText} />

--- a/src/app/(fullscreen)/my-page/temp-saved/page.tsx
+++ b/src/app/(fullscreen)/my-page/temp-saved/page.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import { useQuery } from '@tanstack/react-query';
+
 import { Header } from '@/components/ui/Header';
 
-import MemoirList from '../components/MemoirList';
 import { memoirQueries } from '@/queries/memoirOptions';
-import { useQuery } from '@tanstack/react-query';
+import { PATH } from '@/constants/path';
+
+import MemoirList from '../components/MemoirList';
 
 export default function TempSavedPage() {
   const { data, isPending, isError } = useQuery(memoirQueries.tmp());
@@ -17,15 +20,14 @@ export default function TempSavedPage() {
       <Header title="임시 저장한 글" />
       <div
         className={
-          isEmpty
-            ? 'flex flex-1 items-center justify-center px-5'
-            : 'my-8 flex-1 px-5'
+          isEmpty ? 'flex flex-1 items-center justify-center' : 'my-8 flex-1'
         }
       >
         <MemoirList
           memoirs={memoirs}
           hideBadge={true}
           emptyText="임시 저장한 글이 없어요."
+          itemHrefPattern={PATH.MEMOIR.EDIT.path}
         />
       </div>
     </main>

--- a/src/app/(root)/home/components/HotMemoirList.tsx
+++ b/src/app/(root)/home/components/HotMemoirList.tsx
@@ -99,7 +99,7 @@ export function HotMemoirItem({ memoir }: { memoir: HotMemoir }) {
         <Badge
           size="xsmall"
           shape="minimal"
-          className={interviewStatusClassName}
+          className={cn(interviewStatusClassName, 'mr-1')}
         >
           {memoir.interviewStatus}
         </Badge>

--- a/src/app/(root)/home/components/MemoirStats.tsx
+++ b/src/app/(root)/home/components/MemoirStats.tsx
@@ -1,14 +1,28 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
 import { Button } from '@/components/ui/Button';
 import { PATH } from '@/constants/path';
+import { memoirQueries } from '@/queries/memoirOptions';
 
 export default function MemoirStats() {
+  const { data, isPending } = useQuery(memoirQueries.mine(''));
+  const memoirCount = data?.data?.length ?? 0;
+
   return (
     <section className="bg-foundation-box flex flex-col gap-4 rounded-xl p-5">
       <div className="typo-subhead-03 flex items-center justify-between">
         <span className="text-foundation-strong">지금까지 기록한 회고</span>
         <p>
-          <span className="text-primary-btn">12</span>
-          <span className="text-foundation-strong">개</span>
+          {isPending ? (
+            <span className="text-primary-btn">-</span>
+          ) : (
+            <>
+              <span className="text-primary-btn">{memoirCount}</span>
+              <span className="text-foundation-strong">개</span>
+            </>
+          )}
         </p>
       </div>
       <Button size="large" variant="yellow" href={PATH.MEMOIR.CREATE.path}>

--- a/src/app/(root)/home/components/TodayQuestion.tsx
+++ b/src/app/(root)/home/components/TodayQuestion.tsx
@@ -1,33 +1,52 @@
-import { formatDateToYYMMDD } from '@/utils/date';
-import type { Memoir } from '@/types/memoirTypes';
+'use client';
 
-const mockTodayQuestion: Memoir = {
-  id: 1,
-  type: '퀵회고',
-  interviewStatus: '합격',
-  firstQuestion: '삼성전자의 주가는 앞으로 어떻게 될까요?',
-  companyName: '삼성전자',
-  position: '데이터 분석',
-  createdAt: '2025-07-28',
-};
+import Link from 'next/link';
+
+import { formatDateToYYMMDD } from '@/utils/date';
+import { PATH } from '@/constants/path';
+import { useTodayQuestion } from '@/app/(fullscreen)/home/questions/today/hooks/useTodayQuestion';
 
 export default function TodayQuestion() {
-  const data = mockTodayQuestion;
+  const { todayQuestionData, isPending, isError } = useTodayQuestion();
+
+  if (isPending) {
+    return <TodayQuestionSkeleton />;
+  }
+
+  if (isError || !todayQuestionData) {
+    return null;
+  }
+
+  const { memoir, question } = todayQuestionData;
 
   return (
-    <section className="bg-foundation-box rounded-xl p-5">
-      <h3 className="typo-subhead-02 text-foundation-primary mb-2">
-        오늘의 질문
-      </h3>
-      <div className="typo-subhead-03 mb-2 flex items-center gap-1">
-        <span className="text-secondary-btn">Q.</span>
-        <span className="text-foundation-primary">{data.firstQuestion}</span>
-      </div>
-      <div className="typo-body-long-01 text-foundation-secondary flex items-center gap-2">
-        <span>{formatDateToYYMMDD(data.createdAt)}</span>
-        <span>|</span>
-        <span>{data.companyName}</span>
-      </div>
+    <Link href={PATH.QUESTIONS.TODAY.path}>
+      <section className="bg-foundation-box rounded-xl p-5">
+        <h3 className="typo-subhead-02 text-foundation-primary mb-2">
+          오늘의 질문
+        </h3>
+        <div className="typo-subhead-03 mb-2 flex items-center gap-1">
+          <span className="text-secondary-btn">Q.</span>
+          <span className="text-foundation-primary line-clamp-1">
+            {question.title}
+          </span>
+        </div>
+        <div className="typo-body-long-01 text-foundation-secondary flex items-center gap-2">
+          <span>{formatDateToYYMMDD(memoir.interviewDatetime)}</span>
+          <span>|</span>
+          <span>{memoir.companyName}</span>
+        </div>
+      </section>
+    </Link>
+  );
+}
+
+function TodayQuestionSkeleton() {
+  return (
+    <section className="bg-foundation-box animate-pulse rounded-xl p-5">
+      <div className="bg-foundation-bg mb-2.5 h-5 w-1/4 rounded-md" />
+      <div className="bg-foundation-bg mb-2 h-5 w-3/4 rounded-md" />
+      <div className="bg-foundation-bg h-4 w-1/2 rounded-md" />
     </section>
   );
 }

--- a/src/app/(root)/home/page.tsx
+++ b/src/app/(root)/home/page.tsx
@@ -7,6 +7,7 @@ import MemoirStats from './components/MemoirStats';
 import HotMemoirList from './components/HotMemoirList';
 import MyMemoirList from './components/MyMemoirList';
 import TodayQuestion from './components/TodayQuestion';
+import TriggerRefreshOnce from '@/components/TriggerRefreshOnce';
 
 export const metadata: Metadata = {
   title: 'SEED를 통해',
@@ -17,6 +18,7 @@ export const metadata: Metadata = {
 export default function HomePage() {
   return (
     <div className="px-5">
+      <TriggerRefreshOnce />
       <HomeHeader />
       <div className="mt-[18px] flex flex-col gap-8">
         <TodayQuestion />

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -41,7 +41,7 @@ export async function POST(_req: NextRequest) {
       { status: 500 },
     );
 
-  const accessMax = Number(process.env.ACCESS_MAX_AGE ?? 3600);
+  const accessMax = Number(3600);
   const res = NextResponse.json({}, { status: 204 });
   res.cookies.set('devseed_token', access, {
     httpOnly: true,

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(_req: NextRequest) {
+  const cookieStore = await cookies();
+  const myRefresh = cookieStore.get('devseed_refresh')?.value;
+  if (!myRefresh) {
+    return NextResponse.json({ message: 'No refresh token' }, { status: 401 });
+  }
+
+  const url = `${process.env.NEXT_PUBLIC_DEVSEED_BASE_URL}/auth/refresh`;
+  const upstream = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json, */*;q=0.1',
+      Cookie: `${encodeURIComponent('refresh_token')}=${encodeURIComponent(myRefresh)}`,
+    },
+    cache: 'no-store',
+    redirect: 'manual',
+  });
+
+  const text = await upstream.text();
+  let json = null;
+  try {
+    json = JSON.parse(text);
+  } catch {}
+
+  if (!upstream.ok)
+    return NextResponse.json(
+      { status: upstream.status, upstream: json ?? { raw: text } },
+      { status: upstream.status },
+    );
+
+  const access = json?.data?.accessToken;
+  if (!access)
+    return NextResponse.json(
+      { message: 'No accessToken in response' },
+      { status: 500 },
+    );
+
+  const accessMax = Number(process.env.ACCESS_MAX_AGE ?? 3600);
+  const res = NextResponse.json({}, { status: 204 });
+  res.cookies.set('devseed_token', access, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: accessMax,
+  });
+
+  return res;
+}

--- a/src/app/api/auth/token-info/route.ts
+++ b/src/app/api/auth/token-info/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+export async function GET() {
+  const cookieStore = await cookies();
+  const t = cookieStore.get('devseed_token')?.value;
+  if (!t) return NextResponse.json({ hasToken: false }, { status: 200 });
+  try {
+    const [, payload] = t.split('.');
+    const b64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const pad = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+    const json = JSON.parse(Buffer.from(pad, 'base64').toString('utf8'));
+    const expSec = json?.exp ?? null;
+    return NextResponse.json({
+      hasToken: true,
+      expSec,
+      nowSec: Math.floor(Date.now() / 1000),
+      remainingMs: expSec ? Math.max(0, expSec * 1000 - Date.now()) : null,
+    });
+  } catch {
+    return NextResponse.json({ hasToken: true, expSec: null });
+  }
+}

--- a/src/app/api/set-token/route.ts
+++ b/src/app/api/set-token/route.ts
@@ -1,14 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(req: NextRequest) {
-  const { token, maxAgeSec = 60 * 60 } = await req.json();
+  const {
+    token,
+    refreshToken,
+    maxAgeSec = Number(3600),
+    refreshMaxAgeSec = Number(60 * 60 * 24 * 14),
+  } = await req.json();
 
-  if (!token || typeof token !== 'string') {
+  if (!token)
     return NextResponse.json(
-      { ok: false, error: 'MISSING_TOKEN' },
+      { ok: false, error: 'MISSING_ACCESS_TOKEN' },
       { status: 400 },
     );
-  }
 
   const res = NextResponse.json({ ok: true }, { status: 200 });
   res.cookies.set('devseed_token', token, {
@@ -18,5 +22,14 @@ export async function POST(req: NextRequest) {
     path: '/',
     maxAge: maxAgeSec,
   });
+  if (refreshToken) {
+    res.cookies.set('devseed_refresh', refreshToken, {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+      maxAge: refreshMaxAgeSec,
+    });
+  }
   return res;
 }

--- a/src/app/api/set-token/route.ts
+++ b/src/app/api/set-token/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: NextRequest) {
     refreshMaxAgeSec = Number(60 * 60 * 24 * 14),
   } = await req.json();
 
-  if (!token)
+  if (!token || typeof token !== 'string')
     return NextResponse.json(
       { ok: false, error: 'MISSING_ACCESS_TOKEN' },
       { status: 400 },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import QueryClientProvider from './QueryClientProvider';
+import AuthRefreshManager from '@/components/AuthRefreshManager';
 
 const pretendard = localFont({
   src: './fonts/PretendardVariable.woff2',
@@ -38,6 +39,7 @@ export default function RootLayout({
       <body className={`${pretendard.variable} font-pretendard antialiased`}>
         <QueryClientProvider>
           <div className="bg-foundation-bg max-w-maxWidth mx-auto min-h-screen text-white">
+            <AuthRefreshManager leadSeconds={60} />
             {children}
           </div>
           <ReactQueryDevtools />

--- a/src/app/login/success/_client.tsx
+++ b/src/app/login/success/_client.tsx
@@ -13,6 +13,7 @@ export default function LoginSuccessClient() {
   const clear = useUserStore(s => s.clear);
 
   const token = sp.get('token');
+  const refresh = sp.get('refresh');
 
   useEffect(() => {
     if (!token || postedRef.current) return;
@@ -23,23 +24,31 @@ export default function LoginSuccessClient() {
         const res = await fetch('/api/set-token', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ token }),
+          body: JSON.stringify({
+            token,
+            refreshToken: refresh ?? undefined,
+          }),
+          cache: 'no-store',
         });
+        if (!res.ok) throw new Error('set-token failed');
 
-        if (!res.ok) {
-          alert('로그인에 실패했습니다. 다시 시도해주세요.');
-          router.replace('/');
-          return;
+        if (typeof window !== 'undefined') {
+          const url = new URL(window.location.href);
+          url.searchParams.delete('token');
+          url.searchParams.delete('refresh');
+          window.history.replaceState({}, '', url.toString());
         }
+
         await fetchMyProfile();
+
         router.replace('/home');
       } catch (e) {
         clear();
-        alert('로그인 중 오류가 발생했습니다. 다시 시도해주세요.' + e);
+        alert('로그인 처리 중 오류가 발생했습니다. 다시 시도해주세요.' + e);
         router.replace('/');
       }
     })();
-  }, [token, router, fetchMyProfile, clear]);
+  }, [token, refresh, router, fetchMyProfile, clear]);
 
-  return <div></div>;
+  return null;
 }

--- a/src/assets/icon/bookmark_icon.svg
+++ b/src/assets/icon/bookmark_icon.svg
@@ -1,3 +1,3 @@
-<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M22.1673 24.5L14.0007 18.6667L5.83398 24.5V5.83333C5.83398 5.21449 6.07982 4.621 6.5174 4.18342C6.95499 3.74583 7.54848 3.5 8.16732 3.5H19.834C20.4528 3.5 21.0463 3.74583 21.4839 4.18342C21.9215 4.621 22.1673 5.21449 22.1673 5.83333V24.5Z" stroke="#888888" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="28" height="28" viewBox="0 0 28 28" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+<path d="M22.1673 24.5L14.0007 18.6667L5.83398 24.5V5.83333C5.83398 5.21449 6.07982 4.621 6.5174 4.18342C6.95499 3.74583 7.54848 3.5 8.16732 3.5H19.834C20.4528 3.5 21.0463 3.74583 21.4839 4.18342C21.9215 4.621 22.1673 5.21449 22.1673 5.83333V24.5Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/assets/icon/send_icon.svg
+++ b/src/assets/icon/send_icon.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="24" height="24" rx="12" fill="#30AEFC"/>
+<path d="M12 19V5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5 12L12 5L19 12" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/AuthRefreshManager.tsx
+++ b/src/components/AuthRefreshManager.tsx
@@ -1,0 +1,68 @@
+'use client';
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ *
+ * @param leadSeconds 선제 리프레시 시간(초)
+ * @returns
+ */
+export default function AuthRefreshManager({
+  leadSeconds = 60,
+}: {
+  leadSeconds?: number;
+}) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const setTimer = useCallback(
+    (ms: number, schedule: () => void) => {
+      clearTimer();
+      timerRef.current = setTimeout(async () => {
+        try {
+          const r = await fetch('/api/auth/refresh', {
+            method: 'POST',
+            cache: 'no-store',
+          });
+          if (!r.ok) {
+            if (typeof window !== 'undefined') window.location.assign('/login');
+            return;
+          }
+        } finally {
+          schedule(); // 갱신 후 다음 스케줄
+        }
+      }, ms);
+    },
+    [clearTimer],
+  );
+
+  const schedule = useCallback(async () => {
+    try {
+      const r = await fetch('/api/auth/token-info', { cache: 'no-store' });
+      const j = await r.json();
+
+      if (!j?.hasToken) return;
+      if (!j?.expSec) {
+        setTimer(30 * 60 * 1000, schedule);
+        return;
+      }
+      const refreshAt = j.expSec * 1000 - leadSeconds * 1000;
+      const waitMs = Math.max(5_000, refreshAt - Date.now());
+      setTimer(waitMs, schedule);
+    } catch {
+      setTimer(60 * 1000, schedule);
+    }
+  }, [leadSeconds, setTimer]);
+
+  useEffect(() => {
+    schedule();
+    return () => clearTimer();
+  }, [schedule, clearTimer]);
+
+  return null;
+}

--- a/src/components/TriggerRefreshOnce.tsx
+++ b/src/components/TriggerRefreshOnce.tsx
@@ -1,0 +1,11 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function TriggerRefreshOnce() {
+  useEffect(() => {
+    fetch('/api/auth/refresh', { method: 'POST', cache: 'no-store' }).catch(
+      () => {},
+    );
+  }, []);
+  return null;
+}

--- a/src/constants/labels.ts
+++ b/src/constants/labels.ts
@@ -51,7 +51,7 @@ export const INTERVIEW_METHOD_LABELS = {
 export const INTERVIEW_STATUS_LABELS = {
   [INTERVIEW_STATUS.PASS]: '합격',
   [INTERVIEW_STATUS.FAIL]: '불합격',
-  [INTERVIEW_STATUS.PENDING]: '대기중',
+  [INTERVIEW_STATUS.PENDING]: '결과 대기중',
 } as const;
 
 export const INTERVIEW_STEP_LABELS = {

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -9,6 +9,7 @@ export const PATH = {
     EXPERIENCE: { path: '/home/questions/experience', label: '경험질문' },
     COMPANY: { path: '/home/questions/company', label: '회사질문' },
     FOLLOW_UP: { path: '/home/questions/follow_up', label: '꼬리질문' },
+    TODAY: { path: '/home/questions/today', label: '오늘의 질문' },
   },
 
   INTERVIEW: {

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,4 +1,6 @@
-import axios from 'axios';
+'use client';
+
+import axios, { AxiosError, AxiosRequestConfig } from 'axios';
 
 export type ApiResponse<T> = {
   code: string;
@@ -6,25 +8,62 @@ export type ApiResponse<T> = {
   data: T;
 };
 
+type RetriableConfig = AxiosRequestConfig & { _retry?: boolean };
+
 export const http = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_BASE_URL}/api/proxy`,
   withCredentials: true,
 });
 
-http.interceptors.response.use(
-  response => response,
-  async error => {
-    if (error.response?.status === 401) {
-      if (typeof window !== 'undefined') {
-        window.location.href = '/';
-      }
+if (typeof window !== 'undefined') {
+  // 동시 401 방지(한 번만 refresh 실행)
+  let refreshPromise: Promise<Response> | null = null;
+  async function refreshAccess(): Promise<Response> {
+    if (!refreshPromise) {
+      refreshPromise = fetch('/api/auth/refresh', {
+        method: 'POST',
+        cache: 'no-store',
+      });
+      refreshPromise.finally(() => {
+        refreshPromise = null;
+      });
     }
-    return Promise.reject(error);
-  },
-);
+    return refreshPromise;
+  }
 
-export const internal = axios.create({
-  baseURL: '/api',
-  withCredentials: true,
-  headers: { 'Content-Type': 'application/json' },
-});
+  // /api/auth/refresh 시도 후 성공하면 원래 요청 자동 재시도
+  http.interceptors.response.use(
+    res => res,
+    async (error: AxiosError) => {
+      const status = error.response?.status;
+      const config = (error.config || {}) as RetriableConfig;
+
+      if (status === 401) {
+        const url = config?.url ?? '';
+        const isRefreshCall =
+          url.includes('/api/auth/refresh') || url.includes('/auth/refresh');
+
+        if (!config._retry && !isRefreshCall) {
+          try {
+            const r = await refreshAccess();
+            if (!r.ok) throw new Error('refresh failed');
+
+            config._retry = true;
+            return http.request(config);
+          } catch {
+            if (typeof window !== 'undefined') {
+              window.location.href = '/';
+            }
+            return Promise.reject(error);
+          }
+        }
+
+        if (typeof window !== 'undefined') {
+          window.location.href = '/';
+        }
+      }
+
+      return Promise.reject(error);
+    },
+  );
+}

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -51,16 +51,11 @@ if (typeof window !== 'undefined') {
             config._retry = true;
             return http.request(config);
           } catch {
-            if (typeof window !== 'undefined') {
-              window.location.href = '/';
-            }
+            window.location.href = '/';
             return Promise.reject(error);
           }
         }
-
-        if (typeof window !== 'undefined') {
-          window.location.href = '/';
-        }
+        window.location.href = '/';
       }
 
       return Promise.reject(error);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,13 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
-const PROTECTED = [
-  '/home',
-  '/my-page',
-  '/schedule',
-  '/community',
-  '/api/set-token',
-  '/api/auth/refresh',
-];
+const PROTECTED = ['/home', '/my-page', '/schedule', '/community'];
 const TOKEN_QUERY_KEY = 'token';
 const COOKIE_NAME = process.env.JWT_COOKIE_NAME || 'devseed_token';
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,13 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
-const PROTECTED = ['/home', '/my-page', '/schedule', '/community'];
+const PROTECTED = [
+  '/home',
+  '/my-page',
+  '/schedule',
+  '/community',
+  '/api/set-token',
+  '/api/auth/refresh',
+];
 const TOKEN_QUERY_KEY = 'token';
 const COOKIE_NAME = process.env.JWT_COOKIE_NAME || 'devseed_token';
 

--- a/src/queries/memoirOptions.ts
+++ b/src/queries/memoirOptions.ts
@@ -6,7 +6,10 @@ import {
 } from '@tanstack/react-query';
 
 import * as memoirApi from '@/apis/memoirApi';
-import type { MemoirsRequest } from '@/types/memoirTypes';
+import type {
+  CreateCommentVariables,
+  MemoirsRequest,
+} from '@/types/memoirTypes';
 
 import { memoirKeys } from './queryKeys';
 
@@ -32,11 +35,6 @@ export const memoirQueries = {
     queryOptions({
       queryKey: memoirKeys.tmp(),
       queryFn: memoirApi.getMyTmpMemoirs,
-    }),
-  comments: (memoirId: number) =>
-    queryOptions({
-      queryKey: memoirKeys.comments(memoirId),
-      queryFn: () => memoirApi.getMemoirComments(memoirId),
     }),
 };
 
@@ -96,6 +94,22 @@ export const memoirInfiniteQueries = {
         return lastPage.data.hasNext ? lastPage.data.nextCursor : undefined;
       },
     }),
+
+  // 전체 댓글 조회
+  comments: (memoirId: number) =>
+    infiniteQueryOptions({
+      queryKey: memoirKeys.comments(memoirId),
+      queryFn: ({ pageParam }) =>
+        memoirApi.getMemoirComments({
+          memoirId: Number(memoirId),
+          cursor: pageParam,
+          size: DEFAULT_PAGE_SIZE,
+        }),
+      initialPageParam: null as string | null,
+      getNextPageParam: lastPage => {
+        return lastPage.data.hasNext ? lastPage.data.nextCursor : undefined;
+      },
+    }),
 };
 
 export const memoirMutations = {
@@ -143,7 +157,14 @@ export const memoirMutations = {
     }),
   createComment: (queryClient: QueryClient) =>
     mutationOptions({
-      mutationFn: memoirApi.createMemoirComment,
+      mutationFn: (variables: CreateCommentVariables) => {
+        const { memoirId, content, parentCommentId } = variables;
+        return memoirApi.createMemoirComment({
+          memoirId,
+          content,
+          ...(parentCommentId !== null ? { parentCommentId } : {}),
+        });
+      },
       onSuccess: (_, variables) =>
         queryClient.invalidateQueries({
           queryKey: memoirKeys.comments(variables.memoirId),

--- a/src/types/memoirTypes.ts
+++ b/src/types/memoirTypes.ts
@@ -198,10 +198,26 @@ export interface Comment {
   author: string;
   profileImageUrl: string;
   createdAt: string;
+  isParent?: boolean;
+  children: Comment[] | null;
+}
+
+export interface PaginatedCommentList {
+  pageSize: number;
+  nextCursor: string | null;
+  hasNext: boolean;
+  result: Comment[];
 }
 
 // 북마크 토글
 export interface BookmarkToggleResponse {
   bookMarked: boolean;
   toggledAt: string;
+}
+
+// 댓글 생성 파라미터
+export interface CreateCommentVariables {
+  memoirId: number;
+  content: string;
+  parentCommentId?: number | null;
 }

--- a/src/types/memoirTypes.ts
+++ b/src/types/memoirTypes.ts
@@ -150,6 +150,8 @@ export interface MemoirData {
   createdAt: string;
   isTmp: boolean;
   isPublic: boolean;
+  isLiked: boolean;
+  isBookmarked: boolean;
 }
 
 // 회고 상세 조회


### PR DESCRIPTION
## 🔗 Related Issue

- close #74
- ref #74

---

## ✨ What’s this PR?

<!-- 어떤 기능/수정인지 간단히 설명해주세요 -->
refresh token을 관리하는 기능을 구현합니다.

---

## ✅ Done


---

## 💬 Notes for Reviewer

<!-- 리뷰어가 확인했으면 하는 포인트, 의문점, 논의할 사항 등을 자유롭게 작성해주세요 -->
- 논의할 사항 등을 자유롭게 작성해주세요.

---

## 📷 Screenshot / Demo
![pc](https://example.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic session refresh in the background; initial refresh triggered on Home.
  - Login success stores refresh token and cleans URL.
  - “오늘의 질문” page and Home card now use live data.
  - Alarms list with loading skeletons.
  - Memoir comments with infinite scroll, replies, and a comment drawer.
  - Interactive like/bookmark on memoir detail.

- Improvements
  - Temp-saved memoirs link directly to edit.
  - Home memoir count loads dynamically.
  - Status label updated to “결과 대기중”.
  - Minor badge spacing tweak.
  - Added support for an external image host.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->