### PR TITLE
[✨ feat] 커뮤니티에서 공개된 면접 회고 리스트 조회 연동 (#83)

### DIFF
--- a/src/apis/memoirApi.ts
+++ b/src/apis/memoirApi.ts
@@ -7,11 +7,26 @@ import type {
   MemoirData,
   MemoirsRequest,
   PaginatedMemoirData,
+  PaginatedMemoirListData,
 } from '@/types/memoirTypes';
 
 // 회고 리스트 조회 API (퀵/일반 모두 조회)
-export const getAllMemoirs = async (): Promise<ApiResponse<Memoir[]>> => {
-  const response = await http.get('/memoirs');
+export const getAllMemoirs = async ({
+  position,
+  cursor,
+  size,
+}: {
+  position?: string;
+  cursor?: string | null;
+  size?: number;
+}): Promise<ApiResponse<PaginatedMemoirListData>> => {
+  const response = await http.get('/memoirs', {
+    params: {
+      position,
+      cursor,
+      size,
+    },
+  });
 
   return response.data;
 };

--- a/src/app/(root)/community/components/FeedList.tsx
+++ b/src/app/(root)/community/components/FeedList.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 
+import { useInfiniteQuery } from '@tanstack/react-query';
+
 import RotateIcon from '@/assets/icon/rotate_icon.svg';
 import FilterIcon from '@/assets/icon/filter_icon.svg';
-import { mockMemoirs } from '@/app/(fullscreen)/my-page/mocks/memoir';
 import { SortDropdown } from '@/components/ui/SortDropdown';
 import { Badge } from '@/components/ui/Badge';
 import { Chip } from '@/components/ui/Chip';
@@ -17,8 +18,8 @@ import {
   getMemoirTypeLabel,
   getPositionLabel,
 } from '@/utils/labelUtils';
+import { memoirInfiniteQueries } from '@/queries/memoirOptions';
 import { PATH } from '@/constants/path';
-import { INTERVIEW_STATUS, MEMOIR_TYPES } from '@/constants/code';
 import type {
   InterviewStatus,
   Memoir,
@@ -36,31 +37,60 @@ const sortOptions: { label: string; value: SortType }[] = [
 export default function FeedList() {
   const [selectedSort, setSelectedSort] = useState<SortType>('latest');
   const [isSortPopoverOpen, setIsSortPopoverOpen] = useState(false);
+  const observer = useRef<IntersectionObserver | null>(null);
 
   const router = useRouter();
   const searchParams = useSearchParams();
   const positionFilter = searchParams.get('position');
 
-  const filteredAndSortedMemoirs = useMemo(() => {
-    let filtered = mockMemoirs;
-    if (positionFilter) {
-      filtered = mockMemoirs.filter(
-        memoir => memoir.position === positionFilter,
-      );
-    }
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isPending,
+    isError,
+  } = useInfiniteQuery(
+    memoirInfiniteQueries.all({ position: positionFilter || undefined }),
+  );
 
-    const sorted = [...filtered];
+  const lastElementRef = useCallback(
+    (node: HTMLDivElement) => {
+      if (isFetchingNextPage) return;
+      if (observer.current) observer.current.disconnect();
+
+      observer.current = new IntersectionObserver(entries => {
+        if (entries[0].isIntersecting && hasNextPage) {
+          fetchNextPage();
+        }
+      });
+
+      if (node) observer.current.observe(node);
+    },
+    [isFetchingNextPage, fetchNextPage, hasNextPage],
+  );
+
+  const allMemoirs = useMemo(
+    () => data?.pages.flatMap(page => page.data.result) || [],
+    [data],
+  );
+
+  const countText = hasNextPage ? `${allMemoirs.length}+` : allMemoirs.length;
+
+  const sortedMemoirs = useMemo(() => {
+    const sorted = [...allMemoirs];
     switch (selectedSort) {
       case 'latest':
         return sorted.sort(
           (a, b) =>
             new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
         );
-      // 다른 옵션일 경우 추가 가능
+      case 'popularity':
+        return sorted;
       default:
         return sorted;
     }
-  }, [selectedSort, positionFilter]);
+  }, [selectedSort, allMemoirs]);
 
   const handleResetFilter = () => {
     router.push(PATH.COMMUNITY.MAIN.path);
@@ -82,7 +112,7 @@ export default function FeedList() {
         <div className="flex items-center gap-1">
           <h3 className="typo-body-02 text-white">피드</h3>
           <span className="text-foundation-disabled typo-subhead-02">
-            {filteredAndSortedMemoirs.length}
+            {countText}
           </span>
         </div>
         <SortDropdown
@@ -122,22 +152,49 @@ export default function FeedList() {
           </div>
         </Link>
       </div>
-      {filteredAndSortedMemoirs.map((memoir, index) => (
-        <FeedItem key={memoir.id} memoir={memoir} isFirst={index === 0} />
-      ))}
+      {isPending ? (
+        <>
+          {Array.from({ length: 3 }).map((_, index) => (
+            <FeedItemSkeleton key={index} />
+          ))}
+        </>
+      ) : isError ? (
+        <div className="py-10 text-center">피드를 불러오지 못했습니다.</div>
+      ) : sortedMemoirs.length === 0 ? (
+        <div className="py-10 text-center">
+          {positionFilter
+            ? '해당 직무의 회고가 없습니다.'
+            : '작성된 회고가 없습니다.'}
+        </div>
+      ) : (
+        sortedMemoirs.map((memoir, index) => {
+          if (sortedMemoirs.length === index + 1) {
+            return (
+              <div ref={lastElementRef} key={memoir.id}>
+                <FeedItem memoir={memoir} isFirst={index === 0} />
+              </div>
+            );
+          }
+          return (
+            <FeedItem key={memoir.id} memoir={memoir} isFirst={index === 0} />
+          );
+        })
+      )}
+
+      {isFetchingNextPage && <FeedItemSkeleton />}
     </div>
   );
 }
 
 function FeedItem({ memoir, isFirst }: { memoir: Memoir; isFirst: boolean }) {
   const interviewTypeClassName =
-    memoir.type === MEMOIR_TYPES.QUICK
+    memoir.type === '퀵 회고'
       ? 'text-secondary-btn'
       : 'text-foundation-primary';
   const interviewStatusClassName =
-    memoir.interviewStatus === INTERVIEW_STATUS.PASS
+    memoir.interviewStatus === '합격'
       ? 'text-primary-btn'
-      : memoir.interviewStatus === INTERVIEW_STATUS.PENDING
+      : memoir.interviewStatus === '결과 대기중'
         ? 'text-foundation-secondary'
         : 'text-warning';
 
@@ -194,5 +251,23 @@ function FeedItem({ memoir, isFirst }: { memoir: Memoir; isFirst: boolean }) {
         </div>
       </div>
     </Link>
+  );
+}
+
+function FeedItemSkeleton() {
+  return (
+    <div className="border-foundation-box border-b px-5 py-4">
+      <div className="animate-pulse">
+        <div className="mb-2 flex items-center gap-2">
+          <div className="bg-foundation-bg h-5 w-12 rounded-md" />
+          <div className="bg-foundation-bg h-5 w-14 rounded-md" />
+        </div>
+        <div className="bg-foundation-bg mb-2 h-5 w-3/4 rounded-md" />
+        <div className="flex items-center justify-between">
+          <div className="bg-foundation-bg h-4 w-1/2 rounded-md" />
+          <div className="bg-foundation-bg h-4 w-16 rounded-md" />
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/queries/memoirOptions.ts
+++ b/src/queries/memoirOptions.ts
@@ -13,11 +13,6 @@ import { memoirKeys } from './queryKeys';
 const DEFAULT_PAGE_SIZE = 10;
 
 export const memoirQueries = {
-  all: () =>
-    queryOptions({
-      queryKey: memoirKeys.lists(),
-      queryFn: memoirApi.getAllMemoirs,
-    }),
   detail: (memoirId: number) =>
     queryOptions({
       queryKey: memoirKeys.detail(memoirId),
@@ -46,6 +41,20 @@ export const memoirQueries = {
 };
 
 export const memoirInfiniteQueries = {
+  all: (filters: { position?: string }) =>
+    infiniteQueryOptions({
+      queryKey: memoirKeys.lists(filters),
+      queryFn: ({ pageParam }) =>
+        memoirApi.getAllMemoirs({
+          ...filters,
+          cursor: pageParam,
+          size: DEFAULT_PAGE_SIZE,
+        }),
+      initialPageParam: null as string | null,
+      getNextPageParam: lastPage => {
+        return lastPage.data.hasNext ? lastPage.data.nextCursor : undefined;
+      },
+    }),
   liked: () =>
     infiniteQueryOptions({
       queryKey: memoirKeys.liked({}),

--- a/src/queries/queryKeys.ts
+++ b/src/queries/queryKeys.ts
@@ -1,6 +1,7 @@
 export const memoirKeys = {
   all: ['memoirs'] as const,
-  lists: () => [...memoirKeys.all, 'list'] as const,
+  lists: (filters: object = {}) =>
+    [...memoirKeys.all, 'list', filters] as const,
   hot: () => [...memoirKeys.lists(), 'hot'] as const,
   mine: (searchType: string) =>
     [...memoirKeys.lists(), 'mine', searchType] as const,

--- a/src/types/memoirTypes.ts
+++ b/src/types/memoirTypes.ts
@@ -74,6 +74,13 @@ export interface Memoir {
   isPublic?: boolean;
 }
 
+export interface PaginatedMemoirListData {
+  pageSize: number;
+  nextCursor: string | null;
+  hasNext: boolean;
+  result: Memoir[];
+}
+
 export type ApiMemoirItem = Omit<
   Memoir,
   'interviewStatus' | 'firstQuestion' | 'isTmp' | 'isPublic'


### PR DESCRIPTION
## 🔗 Related Issue

- close #83 
- ref #83

---

## ✨ What’s this PR?

<!-- 어떤 기능/수정인지 간단히 설명해주세요 -->
커뮤니티 페이지에서 공개된 면접 회고 리스트 조회를 연동했어요.

---

## ✅ Done

- [x] 커뮤니티 페이지에서의 회고 리스트 조회 타입, 쿼리 옵션, api를 수정했어요.
- [x] 커뮤니티에서 회고 리스트 api를 연동했어요.

---

## 💬 Notes for Reviewer

<!-- 리뷰어가 확인했으면 하는 포인트, 의문점, 논의할 사항 등을 자유롭게 작성해주세요 -->
- 논의할 사항 등을 자유롭게 작성해주세요.

---

## 📷 Screenshot / Demo
![pc](https://example.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Infinite scrolling for the community feed with seamless page loading.
  - Server-powered pagination for memoirs.
  - Loading skeletons for a smoother experience.
- Improvements
  - Clearer item counts with “+” indicator when more results are available.
  - More informative empty states by position and improved error messaging.
  - Consistent, latest-first sorting with future-ready popularity option.
  - Smoother spacing and rendering for first/last items during load.
- Refactor
  - Updated query structure to support infinite lists and filterable keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->