### PR TITLE
[✨ feat] 이번주 hot 10 회고 api 연동 (#85)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -24,6 +24,18 @@ const nextConfig: NextConfig = {
 
     return config;
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'http',
+        hostname: '**.kakaocdn.net',
+      },
+      {
+        protocol: 'https',
+        hostname: '**.kakaocdn.net',
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/(fullscreen)/home/memoir/hot/components/AllHotMemoirList.tsx
+++ b/src/app/(fullscreen)/home/memoir/hot/components/AllHotMemoirList.tsx
@@ -1,27 +1,49 @@
+'use client';
+
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { useQuery } from '@tanstack/react-query';
+
 import Logo from '@/assets/logo/logo_icon.svg';
 import { Badge } from '@/components/ui/Badge';
-import { INTERVIEW_STATUS, MEMOIR_TYPES } from '@/constants/code';
 import { cn } from '@/utils/cn';
-import {
-  getInterviewStatusLabel,
-  getMemoirTypeLabel,
-} from '@/utils/labelUtils';
-import type {
-  HotMemoir,
-  InterviewStatus,
-  MemoirType,
-} from '@/types/memoirTypes';
-import { mockHotMemoirs } from '@/app/(root)/home/mocks/mockHotMemoirs';
+import { getInterviewStatusLabel } from '@/utils/labelUtils';
+import { memoirQueries } from '@/queries/memoirOptions';
+import type { HotMemoir, InterviewStatus } from '@/types/memoirTypes';
 import { formatTimeAgo } from '@/utils/date';
 import { PATH } from '@/constants/path';
 
 export default function AllHotMemoirList() {
+  const { data, isPending, isError } = useQuery(memoirQueries.hot());
+
+  if (isPending) {
+    return (
+      <div>
+        {Array.from({ length: 5 }).map((_, index) => (
+          <AllHotMemoirItemSkeleton key={index} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="py-10 text-center">
+        HOT 회고를 불러오는 데 실패했습니다.
+      </div>
+    );
+  }
+
+  const hotMemoirs = data?.data || [];
+
+  if (hotMemoirs.length === 0) {
+    return <div className="py-10 text-center">이번주 HOT 회고가 없습니다.</div>;
+  }
+
   return (
     <div>
-      {mockHotMemoirs.map((memoir, index) => (
+      {hotMemoirs.map((memoir, index) => (
         <AllHotMemoirItem
           key={memoir.id}
           memoir={memoir}
@@ -40,13 +62,11 @@ function AllHotMemoirItem({
   isFirst: boolean;
 }) {
   const interviewTypeClassName =
-    memoir.type === MEMOIR_TYPES.QUICK
-      ? 'text-secondary-btn'
-      : 'text-foundation-primary';
+    memoir.type === '퀵 회고' ? 'text-secondary-btn' : 'text-primary-btn';
   const interviewStatusClassName =
-    memoir.interviewStatus === INTERVIEW_STATUS.PASS
+    memoir.interviewStatus === '합격'
       ? 'text-primary-btn'
-      : memoir.interviewStatus === INTERVIEW_STATUS.PENDING
+      : memoir.interviewStatus === '결과 대기중'
         ? 'text-foundation-secondary'
         : 'text-warning';
 
@@ -80,7 +100,7 @@ function AllHotMemoirItem({
             shape="minimal"
             className={interviewTypeClassName}
           >
-            {getMemoirTypeLabel(memoir.type as MemoirType)}
+            {memoir.type}
           </Badge>
         </div>
 
@@ -90,6 +110,8 @@ function AllHotMemoirItem({
               <Image
                 src={memoir.imageUrl}
                 alt={memoir.userName}
+                width={40}
+                height={40}
                 className="h-full w-full rounded-full object-cover"
               />
             ) : (
@@ -129,5 +151,27 @@ function AllHotMemoirItem({
         </div>
       </div>
     </Link>
+  );
+}
+
+function AllHotMemoirItemSkeleton() {
+  return (
+    <div className="border-foundation-box animate-pulse border px-5 py-4">
+      <div className="mb-3 flex items-center gap-2">
+        <div className="bg-foundation-bg h-5 w-12 rounded-md" />
+        <div className="bg-foundation-bg h-5 w-14 rounded-md" />
+      </div>
+      <div className="mt-3 mb-2 flex items-center gap-3">
+        <div className="bg-foundation-bg h-10 w-10 shrink-0 rounded-full" />
+        <div className="flex w-full flex-col gap-1.5">
+          <div className="bg-foundation-bg h-5 w-3/4 rounded-md" />
+          <div className="bg-foundation-bg h-4 w-1/4 rounded-md" />
+        </div>
+      </div>
+      <div className="flex items-start justify-between">
+        <div className="bg-foundation-bg h-4 w-1/2 rounded-md" />
+        <div className="bg-foundation-bg h-4 w-16 rounded-md" />
+      </div>
+    </div>
   );
 }

--- a/src/app/(root)/home/components/HotMemoirList.tsx
+++ b/src/app/(root)/home/components/HotMemoirList.tsx
@@ -4,24 +4,34 @@ import Link from 'next/link';
 import Image from 'next/image';
 
 import { Swiper, SwiperSlide } from 'swiper/react';
+import { useQuery } from '@tanstack/react-query';
 
 import Logo from '@/assets/logo/logo_icon.svg';
 import { Badge } from '@/components/ui/Badge';
 import { calculateDaysAgo } from '@/utils/date';
 import { cn } from '@/utils/cn';
 import { PATH } from '@/constants/path';
+import { memoirQueries } from '@/queries/memoirOptions';
 import type { HotMemoir } from '@/types/memoirTypes';
-
-import { mockHotMemoirs } from '../mocks/mockHotMemoirs';
 
 interface Props {
   isFullWidth?: boolean;
 }
 
 export default function HotMemoirList({ isFullWidth = true }: Props) {
-  const topMemoirs = [...mockHotMemoirs].sort(
+  const {
+    data: hotMemoirData,
+    isPending,
+    isError,
+  } = useQuery(memoirQueries.hot());
+
+  const topMemoirs = (hotMemoirData?.data || []).sort(
     (a, b) => b.weeklyViewCount - a.weeklyViewCount,
   );
+
+  if (isError || (!isPending && topMemoirs.length === 0)) {
+    return null;
+  }
 
   return (
     <section className={cn('flex flex-col gap-4', isFullWidth && '-mx-5')}>
@@ -30,7 +40,11 @@ export default function HotMemoirList({ isFullWidth = true }: Props) {
           <h3 className="typo-subhead-03 text-foundation-primary">
             이번주 HOT 회고
           </h3>
-          <span className="typo-body-01 text-foundation-secondary">10</span>
+          {!isPending && (
+            <span className="typo-body-01 text-foundation-secondary">
+              {topMemoirs.length}
+            </span>
+          )}
         </div>
         <Link href={PATH.MEMOIR.HOT.path}>
           <span className="typo-body-01 text-foundation-secondary">
@@ -45,11 +59,24 @@ export default function HotMemoirList({ isFullWidth = true }: Props) {
           slidesOffsetBefore={20}
           slidesOffsetAfter={20}
         >
-          {topMemoirs.map(memoir => (
-            <SwiperSlide key={memoir.id} style={{ width: '80%' }}>
-              <HotMemoirItem memoir={memoir} />
-            </SwiperSlide>
-          ))}
+          {isPending
+            ? Array.from({ length: 3 }).map((_, index) => (
+                <SwiperSlide key={index} style={{ width: '80%' }}>
+                  <HotMemoirItemSkeleton />
+                </SwiperSlide>
+              ))
+            : topMemoirs.map(memoir => (
+                <SwiperSlide key={memoir.id} style={{ width: '80%' }}>
+                  <Link
+                    href={PATH.MEMOIR.DETAIL.path.replace(
+                      '[id]',
+                      String(memoir.id),
+                    )}
+                  >
+                    <HotMemoirItem memoir={memoir} />
+                  </Link>
+                </SwiperSlide>
+              ))}
         </Swiper>
       </div>
     </section>
@@ -57,13 +84,28 @@ export default function HotMemoirList({ isFullWidth = true }: Props) {
 }
 
 export function HotMemoirItem({ memoir }: { memoir: HotMemoir }) {
-  const className =
-    memoir.type === 'QUICK' ? 'text-secondary-btn' : 'text-primary-btn';
+  const memoirTypeclassName =
+    memoir.type === '퀵 회고' ? 'text-secondary-btn' : 'text-primary-btn';
+  const interviewStatusClassName =
+    memoir.interviewStatus === '합격'
+      ? 'text-primary-btn'
+      : memoir.interviewStatus === '결과 대기중'
+        ? 'text-foundation-secondary'
+        : 'text-warning';
 
   return (
     <section className="bg-foundation-box rounded-xl px-[14px] py-4">
-      <Badge size="xsmall" shape="minimal" className={className}>
-        {memoir.type === 'QUICK' ? '퀵회고' : '일반회고'}
+      {memoir.interviewStatus && (
+        <Badge
+          size="xsmall"
+          shape="minimal"
+          className={interviewStatusClassName}
+        >
+          {memoir.interviewStatus}
+        </Badge>
+      )}
+      <Badge size="xsmall" shape="minimal" className={memoirTypeclassName}>
+        {memoir.type}
       </Badge>
 
       <div className="mt-3 mb-2 flex items-center gap-3">
@@ -72,6 +114,8 @@ export function HotMemoirItem({ memoir }: { memoir: HotMemoir }) {
             <Image
               src={memoir.imageUrl}
               alt={memoir.userName}
+              width={40}
+              height={40}
               className="h-full w-full rounded-full object-cover"
             />
           ) : (
@@ -118,5 +162,29 @@ export function HotMemoirItem({ memoir }: { memoir: HotMemoir }) {
         </span>
       </div>
     </section>
+  );
+}
+
+function HotMemoirItemSkeleton() {
+  return (
+    <div className="bg-foundation-box animate-pulse rounded-xl px-[14px] py-4">
+      <div className="bg-foundation-bg mb-3 h-5 w-14 rounded-md" />
+      <div className="mb-2 flex items-center gap-3">
+        <div className="bg-foundation-bg h-10 w-10 shrink-0 rounded-full" />
+        <div className="flex w-full flex-col gap-1.5">
+          <div className="bg-foundation-bg h-5 w-full rounded-md" />
+          <div className="bg-foundation-bg h-4 w-1/3 rounded-md" />
+        </div>
+      </div>
+      <div className="space-y-1">
+        <div className="bg-foundation-bg h-4 w-full rounded-md" />
+        <div className="bg-foundation-bg h-4 w-5/6 rounded-md" />
+      </div>
+      <div className="bg-foundation-divider my-2 h-px" />
+      <div className="flex items-center justify-between">
+        <div className="bg-foundation-bg h-4 w-1/4 rounded-md" />
+        <div className="bg-foundation-bg h-4 w-1/5 rounded-md" />
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## 🔗 Related Issue

- close #85
- ref #85

---

## ✨ What’s this PR?

<!-- 어떤 기능/수정인지 간단히 설명해주세요 -->
이번주 회고 탑텐 api를 연동했어요.

---

## ✅ Done

- [x] api 연동
- [x] 카카오 이미지 도메인 허용

---

## 💬 Notes for Reviewer

<!-- 리뷰어가 확인했으면 하는 포인트, 의문점, 논의할 사항 등을 자유롭게 작성해주세요 -->
- 논의할 사항 등을 자유롭게 작성해주세요.

---

## 📷 Screenshot / Demo
![pc](https://example.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - HOT 회고 목록이 실시간 데이터로 표시됩니다.
  - 로딩 스켈레톤, 오류 메시지, 빈 상태 안내를 추가했습니다.
  - 헤더에 동적 개수 표시 및 아이템 클릭 시 상세 페이지로 이동이 가능합니다.
  - 회고 유형/상태 배지를 개선해 가독성을 높였습니다.
  - 아바타 이미지 크기를 최적화했습니다.
- Chores
  - 외부 이미지 로딩을 허용하도록 이미지 최적화 도메인(kakaocdn.net)을 구성해 이미지가 정상 표시되도록 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->