### PR TITLE
[✨ feat] 댓글 CR api 연동 (#88)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -34,6 +34,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: '**.kakaocdn.net',
       },
+      {
+        protocol: 'https',
+        hostname: 'devseedstorage.s3.ap-northeast-2.amazonaws.com',
+      },
     ],
   },
 };

--- a/src/apis/memoirApi.ts
+++ b/src/apis/memoirApi.ts
@@ -192,7 +192,7 @@ export const createMemoirComment = async ({
   memoirId: number;
   content: string;
   parentCommentId?: number;
-}): Promise<ApiResponse<Comment>> => {
+}): Promise<ApiResponse<void>> => {
   const response = await http.post(`/memoirs/${memoirId}/comments`, {
     content,
     parentCommentId,

--- a/src/apis/memoirApi.ts
+++ b/src/apis/memoirApi.ts
@@ -6,6 +6,7 @@ import type {
   Memoir,
   MemoirData,
   MemoirsRequest,
+  PaginatedCommentList,
   PaginatedMemoirData,
   PaginatedMemoirListData,
 } from '@/types/memoirTypes';
@@ -163,10 +164,21 @@ export const toggleLikeMemoir = async (
 };
 
 // 댓글 목록 조회 API
-export const getMemoirComments = async (
-  memoirId: number,
-): Promise<ApiResponse<Comment[]>> => {
-  const response = await http.get(`/memoirs/${memoirId}/comments`);
+export const getMemoirComments = async ({
+  memoirId,
+  cursor,
+  size,
+}: {
+  memoirId: number;
+  cursor?: string | null;
+  size?: number;
+}): Promise<ApiResponse<PaginatedCommentList>> => {
+  const response = await http.get(`/memoirs/${memoirId}/comments`, {
+    params: {
+      cursor,
+      size,
+    },
+  });
 
   return response.data;
 };

--- a/src/app/(fullscreen)/home/memoir/[slug]/components/CommentDrawer.tsx
+++ b/src/app/(fullscreen)/home/memoir/[slug]/components/CommentDrawer.tsx
@@ -30,6 +30,8 @@ interface Props {
 export default function CommentDrawer({ memoirId, isOpen, onClose }: Props) {
   const queryClient = useQueryClient();
   const [newComment, setNewComment] = useState('');
+  const [replyToCommentId, setReplyToCommentId] = useState<number | null>(null);
+  const [replyToAuthor, setReplyToAuthor] = useState<string | null>(null);
 
   const {
     data: commentsData,
@@ -78,10 +80,12 @@ export default function CommentDrawer({ memoirId, isOpen, onClose }: Props) {
   const handleCommentSubmit = () => {
     if (!newComment.trim() || isPosting) return;
     createComment(
-      { memoirId, content: newComment },
+      { memoirId, content: newComment, parentCommentId: replyToCommentId },
       {
         onSuccess: () => {
           setNewComment('');
+          setReplyToCommentId(null);
+          setReplyToAuthor(null);
         },
         onError: () => {
           alert('댓글 등록에 실패했습니다.');
@@ -89,6 +93,20 @@ export default function CommentDrawer({ memoirId, isOpen, onClose }: Props) {
       },
     );
   };
+
+  const handleReplyClick = (commentId: number, author: string) => {
+    setReplyToCommentId(commentId);
+    setReplyToAuthor(author);
+  };
+
+  const handleCancelReply = () => {
+    setReplyToCommentId(null);
+    setReplyToAuthor(null);
+  };
+
+  const commentInputPlaceholder = replyToAuthor
+    ? `@${replyToAuthor}님에게 답글 달기...`
+    : '댓글 달기...';
 
   return (
     <BottomDrawer isOpen={isOpen} onOpenChange={open => !open && onClose()}>
@@ -100,6 +118,7 @@ export default function CommentDrawer({ memoirId, isOpen, onClose }: Props) {
           isPending={isPending}
           isError={isError}
           lastCommentRef={lastCommentRef}
+          onReplyClick={handleReplyClick}
         />
         {isFetchingNextPage && (
           <div className="py-2 text-center text-sm text-gray-500">
@@ -113,6 +132,9 @@ export default function CommentDrawer({ memoirId, isOpen, onClose }: Props) {
           onChange={e => setNewComment(e.target.value)}
           onSubmit={handleCommentSubmit}
           isPosting={isPosting}
+          placeholder={commentInputPlaceholder}
+          isReplying={!!replyToCommentId}
+          onCancelReply={handleCancelReply}
         />
       </BottomDrawerFooter>
     </BottomDrawer>

--- a/src/app/(fullscreen)/home/memoir/[slug]/components/CommentDrawer.tsx
+++ b/src/app/(fullscreen)/home/memoir/[slug]/components/CommentDrawer.tsx
@@ -1,0 +1,120 @@
+import { useState, useMemo, useRef, useCallback } from 'react';
+
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+import {
+  BottomDrawer,
+  BottomDrawerContent,
+  BottomDrawerFooter,
+  BottomDrawerHandle,
+  BottomDrawerHeader,
+} from '@/components/ui/Drawer';
+import {
+  memoirInfiniteQueries,
+  memoirMutations,
+} from '@/queries/memoirOptions';
+
+import CommentList from './CommentList';
+import CommentInput from './CommentInput';
+
+interface Props {
+  memoirId: number;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function CommentDrawer({ memoirId, isOpen, onClose }: Props) {
+  const queryClient = useQueryClient();
+  const [newComment, setNewComment] = useState('');
+
+  const {
+    data: commentsData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isPending,
+    isError,
+  } = useInfiniteQuery({
+    ...memoirInfiniteQueries.comments(memoirId),
+    enabled: isOpen,
+  });
+
+  const allComments = useMemo(() => {
+    const flatComments =
+      commentsData?.pages.flatMap(page => page.data.result) || [];
+
+    const uniqueComments = Array.from(
+      new Map(flatComments.map(comment => [comment.id, comment])).values(),
+    );
+
+    return uniqueComments;
+  }, [commentsData]);
+
+  const observer = useRef<IntersectionObserver | null>(null);
+  const lastCommentRef = useCallback(
+    (node: HTMLDivElement) => {
+      if (isFetchingNextPage) return;
+      if (observer.current) observer.current.disconnect();
+
+      observer.current = new IntersectionObserver(entries => {
+        if (entries[0].isIntersecting && hasNextPage) {
+          fetchNextPage();
+        }
+      });
+
+      if (node) observer.current.observe(node);
+    },
+    [isFetchingNextPage, fetchNextPage, hasNextPage],
+  );
+
+  const { mutate: createComment, isPending: isPosting } = useMutation({
+    ...memoirMutations.createComment(queryClient),
+  });
+
+  const handleCommentSubmit = () => {
+    if (!newComment.trim() || isPosting) return;
+    createComment(
+      { memoirId, content: newComment },
+      {
+        onSuccess: () => {
+          setNewComment('');
+        },
+        onError: () => {
+          alert('댓글 등록에 실패했습니다.');
+        },
+      },
+    );
+  };
+
+  return (
+    <BottomDrawer isOpen={isOpen} onOpenChange={open => !open && onClose()}>
+      <BottomDrawerHandle />
+      <BottomDrawerHeader title="댓글" onClose={onClose} />
+      <BottomDrawerContent className="overscroll-contain">
+        <CommentList
+          comments={allComments}
+          isPending={isPending}
+          isError={isError}
+          lastCommentRef={lastCommentRef}
+        />
+        {isFetchingNextPage && (
+          <div className="py-2 text-center text-sm text-gray-500">
+            댓글을 불러오는 중...
+          </div>
+        )}
+      </BottomDrawerContent>
+      <BottomDrawerFooter>
+        <CommentInput
+          value={newComment}
+          onChange={e => setNewComment(e.target.value)}
+          onSubmit={handleCommentSubmit}
+          isPosting={isPosting}
+        />
+      </BottomDrawerFooter>
+    </BottomDrawer>
+  );
+}

--- a/src/app/(fullscreen)/home/memoir/[slug]/components/CommentInput.tsx
+++ b/src/app/(fullscreen)/home/memoir/[slug]/components/CommentInput.tsx
@@ -8,6 +8,9 @@ interface Props {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onSubmit: () => void;
   isPosting: boolean;
+  placeholder?: string;
+  isReplying?: boolean;
+  onCancelReply?: () => void;
 }
 
 export default function CommentInput({
@@ -15,6 +18,9 @@ export default function CommentInput({
   onChange,
   onSubmit,
   isPosting,
+  placeholder = '댓글 달기...',
+  isReplying,
+  onCancelReply,
 }: Props) {
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
@@ -24,17 +30,27 @@ export default function CommentInput({
   };
 
   return (
-    <div className="relative">
-      <Input
-        placeholder="댓글 달기..."
-        value={value}
-        onChange={onChange}
-        onKeyDown={handleKeyDown}
-        className="w-full"
-        disabled={isPosting}
-        icons={<SendIcon />}
-        onClear={onSubmit}
-      />
+    <div className="flex flex-col gap-2">
+      {isReplying && onCancelReply && (
+        <div className="text-foundation-secondary typo-caption flex items-center justify-between px-1">
+          <span>{placeholder.split('...')[0]}</span>
+          <button onClick={onCancelReply} className="flex items-center gap-1">
+            취소
+          </button>
+        </div>
+      )}
+      <div className="relative">
+        <Input
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+          onKeyDown={handleKeyDown}
+          className="w-full"
+          disabled={isPosting}
+          icons={<SendIcon />}
+          onClear={onSubmit}
+        />
+      </div>
     </div>
   );
 }

--- a/src/app/(fullscreen)/home/memoir/[slug]/components/CommentInput.tsx
+++ b/src/app/(fullscreen)/home/memoir/[slug]/components/CommentInput.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { Input } from '@/components/ui/Input';
+import SendIcon from '@/assets/icon/send_icon.svg';
+
+interface Props {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onSubmit: () => void;
+  isPosting: boolean;
+}
+
+export default function CommentInput({
+  value,
+  onChange,
+  onSubmit,
+  isPosting,
+}: Props) {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      onSubmit();
+    }
+  };
+
+  return (
+    <div className="relative">
+      <Input
+        placeholder="댓글 달기..."
+        value={value}
+        onChange={onChange}
+        onKeyDown={handleKeyDown}
+        className="w-full"
+        disabled={isPosting}
+        icons={<SendIcon />}
+        onClear={onSubmit}
+      />
+    </div>
+  );
+}

--- a/src/app/(fullscreen)/home/memoir/[slug]/components/CommentList.tsx
+++ b/src/app/(fullscreen)/home/memoir/[slug]/components/CommentList.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import Image from 'next/image';
+
+import { formatTimeAgo } from '@/utils/date';
+import type { Comment } from '@/types/memoirTypes';
+import Logo from '@/assets/logo/logo_icon.svg';
+
+interface Props {
+  comments: Comment[];
+  isPending: boolean;
+  isError: boolean;
+  lastCommentRef: (node: HTMLDivElement) => void;
+}
+
+export default function CommentList({
+  comments,
+  isPending,
+  isError,
+  lastCommentRef,
+}: Props) {
+  if (isPending) {
+    return (
+      <div className="flex flex-col gap-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <CommentSkeleton key={i} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <div className="py-10 text-center">댓글을 불러오지 못했습니다.</div>;
+  }
+
+  if (comments.length === 0) {
+    return (
+      <div className="text-foundation-primary py-10 text-center">
+        작성된 댓글이 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-8 p-5">
+      {comments.map((comment, index) => {
+        if (comments.length === index + 1) {
+          return (
+            <div ref={lastCommentRef} key={comment.id}>
+              <CommentItem comment={comment} />
+            </div>
+          );
+        }
+        return <CommentItem key={comment.id} comment={comment} />;
+      })}
+    </div>
+  );
+}
+
+function CommentItem({ comment }: { comment: Comment }) {
+  return (
+    <div className="flex items-start gap-3">
+      <figure className="h-10 w-10 shrink-0 rounded-full">
+        {comment.profileImageUrl ? (
+          <Image
+            src={comment.profileImageUrl}
+            alt={comment.author}
+            width={40}
+            height={40}
+            className="h-full w-full rounded-full object-cover"
+          />
+        ) : (
+          <div className="bg-foundation-secondary/20 flex h-full w-full items-center justify-center rounded-full">
+            <Logo height={20} width={20} />
+          </div>
+        )}
+      </figure>
+
+      <div className="flex flex-col">
+        <div className="flex items-center gap-2">
+          <span className="typo-subhead-02 text-foundation-strong">
+            {comment.author}
+          </span>
+          <span className="typo-caption text-foundation-disabled">
+            {formatTimeAgo(comment.createdAt)}
+          </span>
+        </div>
+        <p className="typo-subhead-02 text-foundation-primary whitespace-pre-wrap">
+          {comment.content}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function CommentSkeleton() {
+  return (
+    <div className="flex animate-pulse items-start gap-3 p-5">
+      <div className="bg-foundation-box h-8 w-8 shrink-0 rounded-full" />
+      <div className="flex w-full flex-col gap-1.5">
+        <div className="bg-foundation-box h-4 w-1/2 rounded-md" />
+        <div className="bg-foundation-box h-4 w-full rounded-md" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(fullscreen)/home/memoir/[slug]/components/CommentList.tsx
+++ b/src/app/(fullscreen)/home/memoir/[slug]/components/CommentList.tsx
@@ -11,6 +11,7 @@ interface Props {
   isPending: boolean;
   isError: boolean;
   lastCommentRef: (node: HTMLDivElement) => void;
+  onReplyClick: (commentId: number, author: string) => void;
 }
 
 export default function CommentList({
@@ -18,6 +19,7 @@ export default function CommentList({
   isPending,
   isError,
   lastCommentRef,
+  onReplyClick,
 }: Props) {
   if (isPending) {
     return (
@@ -44,51 +46,78 @@ export default function CommentList({
   return (
     <div className="flex flex-col gap-8 p-5">
       {comments.map((comment, index) => {
-        if (comments.length === index + 1) {
-          return (
-            <div ref={lastCommentRef} key={comment.id}>
-              <CommentItem comment={comment} />
-            </div>
-          );
-        }
-        return <CommentItem key={comment.id} comment={comment} />;
+        const isLastItem = comments.length === index + 1;
+
+        return (
+          <div key={comment.id} ref={isLastItem ? lastCommentRef : null}>
+            <CommentItem comment={comment} onReplyClick={onReplyClick} />
+          </div>
+        );
       })}
     </div>
   );
 }
 
-function CommentItem({ comment }: { comment: Comment }) {
+function CommentItem({
+  comment,
+  onReplyClick,
+}: {
+  comment: Comment;
+  onReplyClick: (commentId: number, author: string) => void;
+}) {
   return (
-    <div className="flex items-start gap-3">
-      <figure className="h-10 w-10 shrink-0 rounded-full">
-        {comment.profileImageUrl ? (
-          <Image
-            src={comment.profileImageUrl}
-            alt={comment.author}
-            width={40}
-            height={40}
-            className="h-full w-full rounded-full object-cover"
-          />
-        ) : (
-          <div className="bg-foundation-secondary/20 flex h-full w-full items-center justify-center rounded-full">
-            <Logo height={20} width={20} />
-          </div>
-        )}
-      </figure>
+    <div className="flex flex-col gap-4">
+      <div className="flex items-start gap-3">
+        <figure className="h-10 w-10 shrink-0 rounded-full">
+          {comment.profileImageUrl ? (
+            <Image
+              src={comment.profileImageUrl}
+              alt={comment.author}
+              width={40}
+              height={40}
+              className="h-full w-full rounded-full object-cover"
+            />
+          ) : (
+            <div className="bg-foundation-secondary/20 flex h-full w-full items-center justify-center rounded-full">
+              <Logo height={20} width={20} />
+            </div>
+          )}
+        </figure>
 
-      <div className="flex flex-col">
-        <div className="flex items-center gap-2">
-          <span className="typo-subhead-02 text-foundation-strong">
-            {comment.author}
-          </span>
-          <span className="typo-caption text-foundation-disabled">
-            {formatTimeAgo(comment.createdAt)}
-          </span>
+        <div className="flex flex-col">
+          <div className="flex items-center gap-2">
+            <span className="typo-subhead-02 text-foundation-strong">
+              {comment.author}
+            </span>
+            <span className="typo-caption text-foundation-disabled">
+              {formatTimeAgo(comment.createdAt)}
+            </span>
+          </div>
+          <p className="typo-subhead-02 text-foundation-primary whitespace-pre-wrap">
+            {comment.content}
+          </p>
+          {comment.isParent && (
+            <button
+              className="typo-caption text-foundation-disabled mt-px w-fit cursor-pointer"
+              onClick={() => onReplyClick(comment.id, comment.author)}
+            >
+              답글달기
+            </button>
+          )}
         </div>
-        <p className="typo-subhead-02 text-foundation-primary whitespace-pre-wrap">
-          {comment.content}
-        </p>
       </div>
+
+      {comment.children && comment.children.length > 0 && (
+        <div className="ml-8 flex flex-col gap-4">
+          {comment.children.map(reply => (
+            <CommentItem
+              key={reply.id}
+              comment={reply}
+              onReplyClick={onReplyClick}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/(fullscreen)/home/memoir/[slug]/components/MemoirDetailAction.tsx
+++ b/src/app/(fullscreen)/home/memoir/[slug]/components/MemoirDetailAction.tsx
@@ -7,9 +7,10 @@ import { cn } from '@/utils/cn';
 
 interface Props {
   isLike?: boolean;
+  onCommentClick?: () => void;
 }
 
-export default function MemoirDetailAction({ isLike }: Props) {
+export default function MemoirDetailAction({ isLike, onCommentClick }: Props) {
   return (
     <div className="border-foundation-divider flex items-center justify-between border-t p-5">
       <div className="flex items-center gap-[14px]">
@@ -24,7 +25,7 @@ export default function MemoirDetailAction({ isLike }: Props) {
         </div>
 
         <div className="flex items-center gap-1">
-          <CommentIcon className="cursor-pointer" />
+          <CommentIcon className="cursor-pointer" onClick={onCommentClick} />
           <span className="text-foundation-secondary typo-subhead-03">12</span>
         </div>
       </div>

--- a/src/app/(fullscreen)/home/memoir/[slug]/components/MemoirDetailView.tsx
+++ b/src/app/(fullscreen)/home/memoir/[slug]/components/MemoirDetailView.tsx
@@ -22,6 +22,7 @@ import type { MemoirData } from '@/types/memoirTypes';
 
 import MemoirDetailContent from './MemoirDetailContent';
 import MemoirDetailAction from './MemoirDetailAction';
+import CommentDrawer from './CommentDrawer';
 
 interface Props {
   memoirData: MemoirData;
@@ -31,6 +32,7 @@ export default function MemoirDetailView({ memoirData }: Props) {
   const router = useRouter();
   const queryClient = useQueryClient();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [isCommentDrawerOpen, setIsCommentDrawerOpen] = useState(false);
 
   const { mutate: deleteMemoir } = useMutation(
     memoirMutations.delete(queryClient),
@@ -78,7 +80,10 @@ export default function MemoirDetailView({ memoirData }: Props) {
 
       {memoirData.isPublic && (
         <footer>
-          <MemoirDetailAction isLike={false} />
+          <MemoirDetailAction
+            isLike={false}
+            onCommentClick={() => setIsCommentDrawerOpen(true)}
+          />
         </footer>
       )}
 
@@ -124,6 +129,12 @@ export default function MemoirDetailView({ memoirData }: Props) {
           </Button>
         </BottomDrawerFooter>
       </BottomDrawer>
+
+      <CommentDrawer
+        memoirId={memoirData.id}
+        isOpen={isCommentDrawerOpen}
+        onClose={() => setIsCommentDrawerOpen(false)}
+      />
     </div>
   );
 }

--- a/src/app/(root)/home/components/HotMemoirList.tsx
+++ b/src/app/(root)/home/components/HotMemoirList.tsx
@@ -99,7 +99,7 @@ export function HotMemoirItem({ memoir }: { memoir: HotMemoir }) {
         <Badge
           size="xsmall"
           shape="minimal"
-          className={interviewStatusClassName}
+          className={cn(interviewStatusClassName, 'mr-1')}
         >
           {memoir.interviewStatus}
         </Badge>

--- a/src/assets/icon/send_icon.svg
+++ b/src/assets/icon/send_icon.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="24" height="24" rx="12" fill="#30AEFC"/>
+<path d="M12 19V5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5 12L12 5L19 12" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/queries/memoirOptions.ts
+++ b/src/queries/memoirOptions.ts
@@ -33,11 +33,6 @@ export const memoirQueries = {
       queryKey: memoirKeys.tmp(),
       queryFn: memoirApi.getMyTmpMemoirs,
     }),
-  comments: (memoirId: number) =>
-    queryOptions({
-      queryKey: memoirKeys.comments(memoirId),
-      queryFn: () => memoirApi.getMemoirComments(memoirId),
-    }),
 };
 
 export const memoirInfiniteQueries = {
@@ -88,6 +83,22 @@ export const memoirInfiniteQueries = {
       queryKey: memoirKeys.bookmarked({}),
       queryFn: ({ pageParam }) =>
         memoirApi.getMyBookmarkedMemoirs({
+          cursor: pageParam,
+          size: DEFAULT_PAGE_SIZE,
+        }),
+      initialPageParam: null as string | null,
+      getNextPageParam: lastPage => {
+        return lastPage.data.hasNext ? lastPage.data.nextCursor : undefined;
+      },
+    }),
+
+  // 전체 댓글 조회
+  comments: (memoirId: number) =>
+    infiniteQueryOptions({
+      queryKey: memoirKeys.comments(memoirId),
+      queryFn: ({ pageParam }) =>
+        memoirApi.getMemoirComments({
+          memoirId: Number(memoirId),
           cursor: pageParam,
           size: DEFAULT_PAGE_SIZE,
         }),

--- a/src/queries/memoirOptions.ts
+++ b/src/queries/memoirOptions.ts
@@ -6,7 +6,10 @@ import {
 } from '@tanstack/react-query';
 
 import * as memoirApi from '@/apis/memoirApi';
-import type { MemoirsRequest } from '@/types/memoirTypes';
+import type {
+  CreateCommentVariables,
+  MemoirsRequest,
+} from '@/types/memoirTypes';
 
 import { memoirKeys } from './queryKeys';
 
@@ -154,7 +157,14 @@ export const memoirMutations = {
     }),
   createComment: (queryClient: QueryClient) =>
     mutationOptions({
-      mutationFn: memoirApi.createMemoirComment,
+      mutationFn: (variables: CreateCommentVariables) => {
+        const { memoirId, content, parentCommentId } = variables;
+        return memoirApi.createMemoirComment({
+          memoirId,
+          content,
+          ...(parentCommentId !== null ? { parentCommentId } : {}),
+        });
+      },
       onSuccess: (_, variables) =>
         queryClient.invalidateQueries({
           queryKey: memoirKeys.comments(variables.memoirId),

--- a/src/types/memoirTypes.ts
+++ b/src/types/memoirTypes.ts
@@ -199,6 +199,7 @@ export interface Comment {
   profileImageUrl: string;
   createdAt: string;
   isParent?: boolean;
+  children: Comment[] | null;
 }
 
 export interface PaginatedCommentList {
@@ -212,4 +213,11 @@ export interface PaginatedCommentList {
 export interface BookmarkToggleResponse {
   bookMarked: boolean;
   toggledAt: string;
+}
+
+// 댓글 생성 파라미터
+export interface CreateCommentVariables {
+  memoirId: number;
+  content: string;
+  parentCommentId?: number | null;
 }

--- a/src/types/memoirTypes.ts
+++ b/src/types/memoirTypes.ts
@@ -198,6 +198,14 @@ export interface Comment {
   author: string;
   profileImageUrl: string;
   createdAt: string;
+  isParent?: boolean;
+}
+
+export interface PaginatedCommentList {
+  pageSize: number;
+  nextCursor: string | null;
+  hasNext: boolean;
+  result: Comment[];
 }
 
 // 북마크 토글


### PR DESCRIPTION
## 🔗 Related Issue

- close #88 
- ref #88

---

## ✨ What’s this PR?

<!-- 어떤 기능/수정인지 간단히 설명해주세요 -->
회고 댓글에 대한 create, read api를 연동했어요.

---

## ✅ Done

- [x] 댓글 조회에 api, 타입, 쿼리 옵션을 수정했어요.
- [x] drawer 내부에 들어갈 `CommnetInput`, `CommentList` 컴포넌트를 추가했어요.
- [x] drawer 컴포넌트 내부에 api를 연동했어요.
- [x] 백엔드 s3 저장소 이미지 도메인을 추가했어요.
- [x] `답글달기`를 누르면 대댓글이 작성되도록 ui를 추가했어요.

---

## 💬 Notes for Reviewer

<!-- 리뷰어가 확인했으면 하는 포인트, 의문점, 논의할 사항 등을 자유롭게 작성해주세요 -->
- 논의할 사항 등을 자유롭게 작성해주세요.

---

## 📷 Screenshot / Demo
![pc](https://example.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Comment drawer on memoir detail with infinite scroll.
  - Reply to specific comments; input supports Enter-to-send and localized UI.
  - Comment button now opens the drawer.

- Improvements
  - Faster, paginated comment loading with next-cursor.
  - Nested comment threads; loading skeletons, error, and empty states for comments.

- UI/Style
  - Improved spacing for the interview status badge in Hot Memoirs.

- Chores
  - Enabled image loading from an additional remote host for better media support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->