### PR TITLE
[✨ feat] 메인페이지에서 회고 개수 가져오기 (#91)

### DIFF
--- a/src/app/(root)/home/components/MemoirStats.tsx
+++ b/src/app/(root)/home/components/MemoirStats.tsx
@@ -1,14 +1,28 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
 import { Button } from '@/components/ui/Button';
 import { PATH } from '@/constants/path';
+import { memoirQueries } from '@/queries/memoirOptions';
 
 export default function MemoirStats() {
+  const { data, isPending } = useQuery(memoirQueries.mine(''));
+  const memoirCount = data?.data?.length ?? 0;
+
   return (
     <section className="bg-foundation-box flex flex-col gap-4 rounded-xl p-5">
       <div className="typo-subhead-03 flex items-center justify-between">
         <span className="text-foundation-strong">지금까지 기록한 회고</span>
         <p>
-          <span className="text-primary-btn">12</span>
-          <span className="text-foundation-strong">개</span>
+          {isPending ? (
+            <span className="text-primary-btn">-</span>
+          ) : (
+            <>
+              <span className="text-primary-btn">{memoirCount}</span>
+              <span className="text-foundation-strong">개</span>
+            </>
+          )}
         </p>
       </div>
       <Button size="large" variant="yellow" href={PATH.MEMOIR.CREATE.path}>


### PR DESCRIPTION
## 🔗 Related Issue

- close #91 
- ref #91

---

## ✨ What’s this PR?

<!-- 어떤 기능/수정인지 간단히 설명해주세요 -->
메인페이지에서 회고 개수 가져오기

---

## ✅ Done

- [x] 메인페이지에서 회고 개수 가져오기

---

## 💬 Notes for Reviewer

<!-- 리뷰어가 확인했으면 하는 포인트, 의문점, 논의할 사항 등을 자유롭게 작성해주세요 -->
- 논의할 사항 등을 자유롭게 작성해주세요.

---

## 📷 Screenshot / Demo
![pc](https://example.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memoir count on the Home screen now updates dynamically based on your actual data, replacing the previous fixed number.
  * Displays a “-” placeholder while loading, then shows the accurate count followed by “개.”
  * Automatically refreshes when your data changes for up-to-date stats.
  * Existing layout and “Create Memoir” button remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->