### PR TITLE
[✨ feat] 오늘의 질문 상세 페이지 제작 (#95)

### DIFF
--- a/src/app/(fullscreen)/home/questions/today/components/TodayQuestionDetail.tsx
+++ b/src/app/(fullscreen)/home/questions/today/components/TodayQuestionDetail.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import Link from 'next/link';
+
+import { Badge } from '@/components/ui/Badge';
+import { EmptyState } from '@/components/ui/Empty';
+import { PATH } from '@/constants/path';
+import { formatDateToYYMMDD } from '@/utils/date';
+import RightIcon from '@/assets/icon/right_arrow_icon.svg';
+
+import { useTodayQuestion } from '../hooks/useTodayQuestion';
+
+export default function TodayQuestionDetail() {
+  const { todayQuestionData, isPending, isError } = useTodayQuestion();
+
+  if (isPending) {
+    return <TodayQuestionSkeleton />;
+  }
+
+  if (isError || !todayQuestionData) {
+    return (
+      <div className="pt-10">
+        <EmptyState text="표시할 질문이 없습니다. 회고를 먼저 작성해주세요." />
+      </div>
+    );
+  }
+
+  const { memoir, question } = todayQuestionData;
+
+  return (
+    <div className="flex flex-col gap-8 p-5">
+      <section>
+        <Badge
+          shape="minimal"
+          size="xsmall"
+          className="text-foundation-primary"
+        >
+          {question.questionType}
+        </Badge>
+        <div className="mt-4 flex flex-col gap-4">
+          <p className="typo-subhead-03">
+            <span className="text-secondary-btn">Q. </span>
+            <span className="text-foundation-strong">{question.title}</span>
+          </p>
+          <p className="typo-body-long-01 text-foundation-secondary whitespace-pre-wrap">
+            A. {question.answer}
+          </p>
+        </div>
+      </section>
+
+      <section>
+        <p className="typo-subhead-03 text-foundation-primary mb-2">
+          회고 정보
+        </p>
+        <Link href={PATH.MEMOIR.DETAIL.path.replace('[id]', String(memoir.id))}>
+          <div className="bg-foundation-box flex cursor-pointer items-center justify-between rounded-xl px-5 py-3">
+            <div>
+              <p className="typo-subhead-long-03 text-foundation-primary">
+                {memoir.companyName}
+              </p>
+              <span className="typo-body-01 text-foundation-secondary">
+                회고일자 {formatDateToYYMMDD(memoir.interviewDatetime)}
+              </span>
+            </div>
+            <RightIcon className="text-foundation-secondary" />
+          </div>
+        </Link>
+      </section>
+    </div>
+  );
+}
+
+function TodayQuestionSkeleton() {
+  return (
+    <div className="animate-pulse p-5">
+      <div className="bg-foundation-box mb-4 h-6 w-24 rounded-md" />
+      <div className="mb-8 space-y-2">
+        <div className="bg-foundation-box h-6 w-full rounded-md" />
+        <div className="bg-foundation-box h-20 w-full rounded-md" />
+      </div>
+      <div className="bg-foundation-box h-20 w-full rounded-xl" />
+    </div>
+  );
+}

--- a/src/app/(fullscreen)/home/questions/today/hooks/useTodayQuestion.ts
+++ b/src/app/(fullscreen)/home/questions/today/hooks/useTodayQuestion.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { memoirQueries } from '@/queries/memoirOptions';
+
+const FEATURED_MEMOIR_ID = 20;
+
+export function useTodayQuestion() {
+  const {
+    data: memoirDetailResponse,
+    isPending,
+    isError,
+  } = useQuery(memoirQueries.detail(FEATURED_MEMOIR_ID));
+
+  const todayQuestionData = useMemo(() => {
+    const memoirDetail = memoirDetailResponse?.data;
+    if (!memoirDetail || !memoirDetail.questions?.[0]) {
+      return null;
+    }
+
+    return {
+      memoir: memoirDetail,
+      question: memoirDetail.questions[0],
+    };
+  }, [memoirDetailResponse]);
+
+  return {
+    todayQuestionData,
+    isPending,
+    isError,
+  };
+}

--- a/src/app/(fullscreen)/home/questions/today/page.tsx
+++ b/src/app/(fullscreen)/home/questions/today/page.tsx
@@ -1,0 +1,17 @@
+import { Header } from '@/components/ui/Header';
+
+import TodayQuestionDetail from './components/TodayQuestionDetail';
+
+export const metadata = {
+  title: '오늘의 질문',
+  description: '오늘의 질문에 대한 상세 정보를 확인하세요.',
+};
+
+export default function TodayQuestion() {
+  return (
+    <div>
+      <Header title="오늘의 질문" />
+      <TodayQuestionDetail />
+    </div>
+  );
+}

--- a/src/app/(root)/home/components/TodayQuestion.tsx
+++ b/src/app/(root)/home/components/TodayQuestion.tsx
@@ -1,33 +1,52 @@
-import { formatDateToYYMMDD } from '@/utils/date';
-import type { Memoir } from '@/types/memoirTypes';
+'use client';
 
-const mockTodayQuestion: Memoir = {
-  id: 1,
-  type: '퀵회고',
-  interviewStatus: '합격',
-  firstQuestion: '삼성전자의 주가는 앞으로 어떻게 될까요?',
-  companyName: '삼성전자',
-  position: '데이터 분석',
-  createdAt: '2025-07-28',
-};
+import Link from 'next/link';
+
+import { formatDateToYYMMDD } from '@/utils/date';
+import { PATH } from '@/constants/path';
+import { useTodayQuestion } from '@/app/(fullscreen)/home/questions/today/hooks/useTodayQuestion';
 
 export default function TodayQuestion() {
-  const data = mockTodayQuestion;
+  const { todayQuestionData, isPending, isError } = useTodayQuestion();
+
+  if (isPending) {
+    return <TodayQuestionSkeleton />;
+  }
+
+  if (isError || !todayQuestionData) {
+    return null;
+  }
+
+  const { memoir, question } = todayQuestionData;
 
   return (
-    <section className="bg-foundation-box rounded-xl p-5">
-      <h3 className="typo-subhead-02 text-foundation-primary mb-2">
-        오늘의 질문
-      </h3>
-      <div className="typo-subhead-03 mb-2 flex items-center gap-1">
-        <span className="text-secondary-btn">Q.</span>
-        <span className="text-foundation-primary">{data.firstQuestion}</span>
-      </div>
-      <div className="typo-body-long-01 text-foundation-secondary flex items-center gap-2">
-        <span>{formatDateToYYMMDD(data.createdAt)}</span>
-        <span>|</span>
-        <span>{data.companyName}</span>
-      </div>
+    <Link href={PATH.QUESTIONS.TODAY.path}>
+      <section className="bg-foundation-box rounded-xl p-5">
+        <h3 className="typo-subhead-02 text-foundation-primary mb-2">
+          오늘의 질문
+        </h3>
+        <div className="typo-subhead-03 mb-2 flex items-center gap-1">
+          <span className="text-secondary-btn">Q.</span>
+          <span className="text-foundation-primary line-clamp-1">
+            {question.title}
+          </span>
+        </div>
+        <div className="typo-body-long-01 text-foundation-secondary flex items-center gap-2">
+          <span>{formatDateToYYMMDD(memoir.interviewDatetime)}</span>
+          <span>|</span>
+          <span>{memoir.companyName}</span>
+        </div>
+      </section>
+    </Link>
+  );
+}
+
+function TodayQuestionSkeleton() {
+  return (
+    <section className="bg-foundation-box animate-pulse rounded-xl p-5">
+      <div className="bg-foundation-bg mb-2.5 h-5 w-1/4 rounded-md" />
+      <div className="bg-foundation-bg mb-2 h-5 w-3/4 rounded-md" />
+      <div className="bg-foundation-bg h-4 w-1/2 rounded-md" />
     </section>
   );
 }

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -9,6 +9,7 @@ export const PATH = {
     EXPERIENCE: { path: '/home/questions/experience', label: '경험질문' },
     COMPANY: { path: '/home/questions/company', label: '회사질문' },
     FOLLOW_UP: { path: '/home/questions/follow_up', label: '꼬리질문' },
+    TODAY: { path: '/home/questions/today', label: '오늘의 질문' },
   },
 
   INTERVIEW: {


### PR DESCRIPTION
## 🔗 Related Issue

- close #95 
- ref #95

---

## ✨ What’s this PR?

<!-- 어떤 기능/수정인지 간단히 설명해주세요 -->
오늘의 질문 상세 페이지 제작

---

## ✅ Done

- [x] 오늘의 질문 상세 페이지 제작

---

## 💬 Notes for Reviewer

<!-- 리뷰어가 확인했으면 하는 포인트, 의문점, 논의할 사항 등을 자유롭게 작성해주세요 -->
- 논의할 사항 등을 자유롭게 작성해주세요.

---

## 📷 Screenshot / Demo
![pc](https://example.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced “오늘의 질문” page with header and detailed view.
  - Displays loading skeleton, empty state on errors/missing data, and a badge with question type when available.
  - Shows question title, answer, company name, and formatted interview date.
  - Added navigation to related 회고 상세 페이지 and a new app route for “오늘의 질문”.

- Refactor
  - Home widget for “오늘의 질문” now uses live data instead of mock content, with proper loading and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->