### PR TITLE
[✨ feat] 회고 임시 저장 처리한 회고 다시 불러와 수정할 수 있도록 제작 (#99)

### DIFF
--- a/src/app/(fullscreen)/home/memoir/general/components/GeneralMemoirView.tsx
+++ b/src/app/(fullscreen)/home/memoir/general/components/GeneralMemoirView.tsx
@@ -42,8 +42,8 @@ export default function GeneralMemoirView({
   );
   const isPending = isCreatePending || isUpdatePending;
 
-  const handleSave = () => {
-    if (!isSaveButtonEnabled) return;
+  const handleSubmit = (isDraft: boolean) => {
+    if (!isDraft && !isSaveButtonEnabled) return;
 
     const payload: Omit<MemoirsRequest, 'id'> = {
       type: MEMOIR_TYPES.GENERAL,
@@ -58,7 +58,13 @@ export default function GeneralMemoirView({
         answer: q.answer,
         order: index + 1,
       })),
-      isTmp: false,
+      isTmp: isDraft,
+    };
+
+    const handleSuccess = (message: string, redirectPath: string) => {
+      alert(message);
+      resetForm();
+      router.push(redirectPath);
     };
 
     if (mode === 'edit' && memoirId) {
@@ -66,40 +72,41 @@ export default function GeneralMemoirView({
         { ...payload, id: memoirId },
         {
           onSuccess: () => {
-            alert('회고가 성공적으로 수정되었습니다!');
-            resetForm();
-            router.push(
-              PATH.MEMOIR.DETAIL.path.replace('[id]', String(memoirId)),
-            );
+            const message = `회고가 성공적으로 ${isDraft ? '임시저장' : '수정'}되었습니다!`;
+            const path = isDraft
+              ? PATH.MY_PAGE.TEMP_SAVED.path
+              : PATH.MEMOIR.DETAIL.path.replace('[id]', String(memoirId));
+            handleSuccess(message, path);
           },
-          onError: () => {
-            alert('회고 수정에 실패했습니다. 다시 시도해주세요.');
-          },
+          onError: () =>
+            alert(`회고 ${isDraft ? '임시저장' : '수정'}에 실패했습니다.`),
         },
       );
     } else {
       createMemoir(payload, {
         onSuccess: response => {
-          const newMemoirId = response.data;
+          const newMemoirId = response.data.id;
           if (newMemoirId) {
-            alert('회고가 성공적으로 저장되었습니다!');
-            resetForm();
-            const detailPath = PATH.MEMOIR.DETAIL.path.replace(
-              '[id]',
-              String(newMemoirId),
-            );
-            router.push(detailPath);
+            const message = `회고가 성공적으로 ${isDraft ? '임시저장' : '저장'}되었습니다!`;
+            const path = isDraft
+              ? PATH.MY_PAGE.MEMOIRS.path
+              : PATH.MEMOIR.DETAIL.path.replace('[id]', String(newMemoirId));
+            handleSuccess(message, path);
           } else {
-            alert('회고가 저장되었지만, 홈으로 이동합니다.');
-            router.push(PATH.HOME.path);
+            handleSuccess(
+              '회고가 저장되었지만, 홈으로 이동합니다.',
+              PATH.HOME.path,
+            );
           }
         },
-        onError: () => {
-          alert('회고 저장에 실패했습니다. 다시 시도해주세요.');
-        },
+        onError: () =>
+          alert(`회고 ${isDraft ? '임시저장' : '저장'}에 실패했습니다.`),
       });
     }
   };
+
+  const handleSave = () => handleSubmit(false);
+  const handleSaveDraft = () => handleSubmit(true);
 
   return (
     <div className="flex h-screen flex-col">
@@ -114,7 +121,12 @@ export default function GeneralMemoirView({
 
       <footer className="px-5 pt-4 pb-6">
         <div className="flex gap-2">
-          <Button variant="outline" size="small">
+          <Button
+            variant="outline"
+            size="small"
+            onClick={handleSaveDraft}
+            disabled={isPending}
+          >
             임시저장
           </Button>
           <Button

--- a/src/app/(fullscreen)/my-page/components/MemoirItem.tsx
+++ b/src/app/(fullscreen)/my-page/components/MemoirItem.tsx
@@ -8,13 +8,20 @@ import { PATH } from '@/constants/path';
 interface Props {
   memoir: ApiMemoirItem;
   hideBadge?: boolean;
+  hrefPattern?: string;
 }
 
-export default function MemoirItem({ memoir, hideBadge = false }: Props) {
+export default function MemoirItem({
+  memoir,
+  hideBadge = false,
+  hrefPattern,
+}: Props) {
   const badgeTextColor =
     memoir.type === '퀵 회고' ? 'text-secondary-btn' : 'text-primary-btn';
 
-  const detailPath = PATH.MEMOIR.DETAIL.path.replace('[id]', String(memoir.id));
+  const detailPath =
+    hrefPattern?.replace('[id]', String(memoir.id)) ??
+    PATH.MEMOIR.DETAIL.path.replace('[id]', String(memoir.id));
 
   return (
     <Link href={detailPath}>

--- a/src/app/(fullscreen)/my-page/components/MemoirList.tsx
+++ b/src/app/(fullscreen)/my-page/components/MemoirList.tsx
@@ -7,15 +7,26 @@ interface Props {
   memoirs: ApiMemoirItem[];
   hideBadge?: boolean;
   emptyText: string;
+  itemHrefPattern?: string;
 }
 
-export default function MemoirList({ memoirs, hideBadge, emptyText }: Props) {
+export default function MemoirList({
+  memoirs,
+  hideBadge,
+  emptyText,
+  itemHrefPattern,
+}: Props) {
   return (
     <>
       <div className="mb-5 flex flex-1 flex-col gap-3 px-5">
         {memoirs.length > 0 ? (
           memoirs.map(memoir => (
-            <MemoirItem key={memoir.id} memoir={memoir} hideBadge={hideBadge} />
+            <MemoirItem
+              key={memoir.id}
+              memoir={memoir}
+              hideBadge={hideBadge}
+              hrefPattern={itemHrefPattern}
+            />
           ))
         ) : (
           <EmptyState text={emptyText} />

--- a/src/app/(fullscreen)/my-page/temp-saved/page.tsx
+++ b/src/app/(fullscreen)/my-page/temp-saved/page.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import { useQuery } from '@tanstack/react-query';
+
 import { Header } from '@/components/ui/Header';
 
-import MemoirList from '../components/MemoirList';
 import { memoirQueries } from '@/queries/memoirOptions';
-import { useQuery } from '@tanstack/react-query';
+import { PATH } from '@/constants/path';
+
+import MemoirList from '../components/MemoirList';
 
 export default function TempSavedPage() {
   const { data, isPending, isError } = useQuery(memoirQueries.tmp());
@@ -17,15 +20,14 @@ export default function TempSavedPage() {
       <Header title="임시 저장한 글" />
       <div
         className={
-          isEmpty
-            ? 'flex flex-1 items-center justify-center px-5'
-            : 'my-8 flex-1 px-5'
+          isEmpty ? 'flex flex-1 items-center justify-center' : 'my-8 flex-1'
         }
       >
         <MemoirList
           memoirs={memoirs}
           hideBadge={true}
           emptyText="임시 저장한 글이 없어요."
+          itemHrefPattern={PATH.MEMOIR.EDIT.path}
         />
       </div>
     </main>


### PR DESCRIPTION
## 🔗 Related Issue

- close #99
- ref #99

---

## ✨ What’s this PR?

<!-- 어떤 기능/수정인지 간단히 설명해주세요 -->
회고 임시 저장 처리한 회고 다시 불러와 수정할 수 있도록 제작

---

## ✅ Done

- [x] 회고 임시 저장 처리한 회고 다시 불러와 수정할 수 있도록 제작

---

## 💬 Notes for Reviewer

<!-- 리뷰어가 확인했으면 하는 포인트, 의문점, 논의할 사항 등을 자유롭게 작성해주세요 -->
- 논의할 사항 등을 자유롭게 작성해주세요.

---

## 📷 Screenshot / Demo
![pc](https://example.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Memoir saving now supports draft and final saves with clearer success/error messages and appropriate redirects (drafts to Temp Saved, final to detail).
  - Draft button is wired for temporary save and is disabled while submitting; final save respects form validity and submission state.
  - Temp Saved list items now open directly in edit mode via updated links.

- Style
  - Reduced padding on the Temp Saved page for a tighter layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->